### PR TITLE
Add Support for Initializing Anonymous Structs

### DIFF
--- a/smpl/src/analysis/error.rs
+++ b/smpl/src/analysis/error.rs
@@ -104,6 +104,11 @@ pub enum TypeError {
         span: Span,
     },
 
+    InvalidInitialization {
+        fields: Vec<Ident>,
+        span: Span,
+    },
+
     UnknownField {
         name: Ident,
         struct_type: Type,

--- a/smpl/src/analysis/expr_flow.rs
+++ b/smpl/src/analysis/expr_flow.rs
@@ -67,6 +67,27 @@ pub fn flatten_expr(universe: &Universe, scope: &mut Expr, e: AstExpr) -> (TmpId
             )
         }
 
+        AstExpr::AnonStructInit(init) => {
+            let (init, span) = init.to_data();
+            let field_init = init.field_init.map(|field_init_list| {
+                field_init_list
+                    .into_iter()
+                    .map(|(name, expr)| {
+                        let expr = flatten_expr(universe, scope, *expr).0;
+                        (name.data().clone(), expr)
+                    })
+                    .collect::<Vec<_>>()
+            });
+            (
+                scope.map_tmp(
+                    universe,
+                    Value::AnonStructInit(AnonStructInit::new(field_init)),
+                    span,
+                ),
+                span,
+            )
+        }
+
         AstExpr::Binding(ident) => {
             let span = ident.span();
             (

--- a/smpl/src/analysis/fn_analyzer.rs
+++ b/smpl/src/analysis/fn_analyzer.rs
@@ -514,7 +514,7 @@ impl<'a> FnAnalyzer<'a> {
 
                     match init.field_init() {
                         Some(init_list) => {
-                            if init_list.len() != fields.len() {
+                            if init_list.len() < fields.len() {
                                 // Missing fields -> struct is not fully initialized
                                 return Err(TypeError::StructNotFullyInitialized {
                                     type_name: type_name.clone(),
@@ -534,7 +534,13 @@ impl<'a> FnAnalyzer<'a> {
                                     span: tmp.span(),
                                 }
                                 .into());
+                            } else if init_list.len() > fields.len() {
+                                return Err(TypeError::InvalidInitialization {
+                                    fields: init.init_order().unwrap().map(|i| i.clone()).collect(),
+                                    span: tmp.span(),
+                                }.into());
                             }
+
                             // Go threw initialization list and check expressions
                             for (ref id, ref typed_tmp_id) in init_list {
                                 let field_type = fields.get(id).unwrap();

--- a/smpl/src/analysis/fn_analyzer.rs
+++ b/smpl/src/analysis/fn_analyzer.rs
@@ -578,6 +578,11 @@ impl<'a> FnAnalyzer<'a> {
                     tmp_type = struct_type;
                 }
 
+                Value::AnonStructInit(ref init) => {
+                    init.set_init(self.program.universe_mut(), expr);
+                    tmp_type = init.struct_type().unwrap();
+                }
+
                 Value::Binding(ref var) => match self.current_scope.binding_info(var.ident())? {
                     BindingInfo::Var(var_id, type_id) => {
                         var.set_id(var_id);

--- a/smpl/src/analysis/fn_analyzer.rs
+++ b/smpl/src/analysis/fn_analyzer.rs
@@ -579,7 +579,12 @@ impl<'a> FnAnalyzer<'a> {
                 }
 
                 Value::AnonStructInit(ref init) => {
-                    init.set_init(self.program.universe_mut(), expr);
+                    if let Err(duplicate_fields) = init.set_init(self.program.universe_mut(), expr) {
+                        return Err(TypeError::InvalidInitialization {
+                            fields: duplicate_fields,
+                            span: tmp.span(),
+                        }.into());
+                    }
                     tmp_type = init.struct_type().unwrap();
                 }
 

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1530,4 +1530,55 @@ fn foo(type T)(t: T)
         let mod1 = parse_module(wrap_input!(mod1)).unwrap();
         assert!(check_program(vec![mod1]).is_err());
     }
+
+    #[test]
+    fn generic_struct_init_type_arg() {
+        let mod1 =
+"mod mod1;
+
+struct Foo(type T) {
+    x: T
+}
+
+fn foo() {
+    let f: Foo(type int) = init Foo(type int) {
+        x: 5,
+    };
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let result = check_program(vec![mod1]).unwrap();
+
+    }
+
+    #[test]
+    fn generic_struct_init_width_constraint() {
+        let mod1 =
+"mod mod1;
+
+struct Bar {
+    y: bool,
+}
+
+struct Foo(type T) 
+    where T: { y: bool } {
+    x: T
+}
+
+fn foo() {
+    let b = init Bar {
+        y: false,
+    };
+
+    let f: Foo(type Bar) = init Foo(type Bar) {
+        x: b,
+    };
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let result = check_program(vec![mod1]).unwrap();
+
+    }
+
+
 }

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1589,6 +1589,7 @@ fn foo() {
     let f: { x: int, y: bool } = init {
         y: true,
         x: 15,
+        z: \"bla\",
     };
 }
 ";

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1580,5 +1580,35 @@ fn foo() {
 
     }
 
+    #[test]
+    fn anonymous_struct_init() {
+        let mod1 =
+"mod mod1;
 
+fn foo() {
+    let f: { x: int, y: bool } = init {
+        y: true,
+        x: 15,
+    };
+}
+";
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let result = check_program(vec![mod1]).unwrap();
+    }
+
+    #[test]
+    fn anonymous_struct_init_invalid_type() {
+        let mod1 =
+"mod mod1;
+
+fn foo() {
+    let f: { x: int, y: bool, z: String } = init {
+        y: true,
+        x: 15,
+    };
+}
+";
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        assert!(check_program(vec![mod1]).is_err());
+    }
 }

--- a/smpl/src/ast.rs
+++ b/smpl/src/ast.rs
@@ -177,6 +177,11 @@ impl PartialEq for ExprStmt {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub struct AnonStructInit {
+    pub field_init: Option<Vec<(AstNode<Ident>, Box<Expr>)>>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct StructInit {
     pub struct_name: TypedPath,
     pub field_init: Option<Vec<(AstNode<Ident>, Box<Expr>)>>,
@@ -222,6 +227,7 @@ pub enum Expr {
     FieldAccess(AstNode<Path>),
     FnCall(AstNode<FnCall>),
     StructInit(AstNode<StructInit>),
+    AnonStructInit(AstNode<AnonStructInit>),
     ArrayInit(AstNode<ArrayInit>),
     Indexing(AstNode<Indexing>),
     AnonymousFn(AstNode<AnonymousFn>),

--- a/smpl/src/code_gen/interpreter/avm/expr_eval.rs
+++ b/smpl/src/code_gen/interpreter/avm/expr_eval.rs
@@ -471,6 +471,26 @@ fn eval_tmp(_program: &Program, context: &mut ExecutionContext, tmp: &Tmp) -> Tm
             Value::Struct(s)
         }
 
+        AbstractValue::AnonStructInit(ref init) => {
+            // Exactly the same as regular init
+            let mut s = Struct::new();
+
+            match init.field_init() {
+                Some(ref v) => {
+                    let init_order = init.init_order().unwrap();
+                    for (ident, (_, ref tmp)) in init_order.into_iter().zip(v.iter()) {
+                        let field_value =
+                            context.top().func_env.get_tmp(tmp.data().clone()).unwrap();
+                        s.set_field(ident.as_str().to_string(), field_value.clone());
+                    }
+                }
+
+                None => (),
+            }
+
+            Value::Struct(s)
+        }
+
         AbstractValue::ArrayInit(ref init) => match *init {
             ArrayInit::List(ref v) => Value::Array(
                 v.iter()

--- a/smpl/src/parser/parser_tests.rs
+++ b/smpl/src/parser/parser_tests.rs
@@ -131,6 +131,46 @@ init NAME {
     }
 
     #[test]
+    fn test_parse_anonymous_struct_init() {
+        let init_1 = r##" init { }"##;
+        let init_2 = r##"
+init {
+    field1: 1 + 2,
+    field2: true
+}
+"##;
+
+        let init_1 = parse_expr_quick(init_1);
+        let init_2 = parse_expr_quick(init_2);
+
+        // Check init_1
+        {
+            let expected = Expr::AnonStructInit(dummy_node!(AnonStructInit {
+                field_init: None,
+            }));
+
+            assert_eq!(init_1, expected);
+        }
+
+        // Check init_2
+        {
+            let field_init = bin_expr!((int!(1 => BoxExpr), 
+                                        BinOp::Add, 
+                                        int!(2 => BoxExpr)) => BoxExpr);
+            let field2_init = boolean!(true => BoxExpr);
+
+            let expected = Expr::AnonStructInit(dummy_node!(AnonStructInit {
+                field_init: Some(vec![
+                    (dummy_node!(ident!("field1")), field_init),
+                    (dummy_node!(ident!("field2")), field2_init)
+                ]),
+            }));
+
+            assert_eq!(init_2, expected);
+        }
+    }
+
+    #[test]
     fn test_parse_complex_expr() {
         let input = r##"5 != 3 || "something" == false && true"##;
         let expr = parse_expr_quick(input);


### PR DESCRIPTION
Add support for initializing anonymous structs.

Uses the same typing infrastructure for Width Constraints. The only addition is the initialization syntax with minor adjustments to expression analysis.

```
let f: { x: int, y: int } = init {
  y: 5,
  x: 2,
};

let b = f;   // Same type as f
```