### PR TITLE
Function Subtyping Fix

### DIFF
--- a/smpl/src/analysis/type_resolver.rs
+++ b/smpl/src/analysis/type_resolver.rs
@@ -104,6 +104,16 @@ pub fn resolve_types(synthesis: &Type, constraint: &Type) -> bool {
 
 fn resolve_param(synth: &Type, constraint: &Type) -> bool {
     match (synth, constraint) {
+
+        // If the constraint is a width constraint, the provided parameter type cannot be a nominal
+        // type. Values of nominal types may carry additional metadata that is generally difficult to
+        // construct from anonymous types. On the otherhand, its simple to strip this metadata from
+        // values of nominal types.
+        //
+        // The constraint being a width constriant means that in general, an anonymous struct will
+        // be provided to the concrete function.
+        (Record { .. }, WidthConstraint { .. }) => false,
+
         (WidthConstraint {
             fields: ref synth_width,
             field_map: ref synth_map,

--- a/smpl/src/analysis/type_resolver.rs
+++ b/smpl/src/analysis/type_resolver.rs
@@ -110,13 +110,17 @@ fn resolve_param(synth: &Type, constraint: &Type) -> bool {
         }, WidthConstraint {
             fields: ref constraint_width,
             field_map: ref constraint_map,
-        }) | (Record {
+        }) | 
+        
+        // NOTE(alex): Synth width must be narrower than the nominal record constraint
+        // Calling with the nominal record value on the width constraint is allowed
+        (WidthConstraint {
             fields: ref synth_width,
             field_map: ref synth_map,
-            ..
-        }, WidthConstraint {
+        }, Record {
             fields: ref constraint_width,
             field_map: ref constraint_map,
+            ..
         }) => {
 
             // In function parameters, types must be contravariant


### PR DESCRIPTION
Issue: #1 
While determining subtypes of function types, function parameters are contravariant while return type remains covariant. This means:

- If a parameter is expected to be a nominal type, the subtype's parameter must be equal or a narrower type.
- If a parameter is expected to be a width constraint, the subtype's parameter must be equal or a narrower type.
- If a parameter is expected to be a width constraint but a nominal type is provided, reject. Values of a nominal type may carry extra metadata which cannot be reconstructed from a general anonymous struct. Therefore, a parameter with type of an anonymous struct cannot be used where a nominal type is expected. This restriction holds elsewhere in SMPL. Conversely, its trivial to convert a value of a nominal type to an anonymous type of equal or narrower width. Simply discard extra fields and any metadata.
