### PR TITLE
Fix Parser Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ exclude = [
 	"smpl-tests/target/basic_tests",
 	"smplc",
 ]
+
+[patch.crates-io]
+smpl = { path = "./smpl" }

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1688,4 +1688,22 @@ fn test() {
         assert!(check_program(vec![mod1]).is_err());
     }
 
+    #[test]
+    fn bind_fn_type_app() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}
+
+fn test() {
+    let my_ident: fn(int) -> int = ident(type int);
+    let result: int = my_ident(5);
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        check_program(vec![mod1]).unwrap();
+    }
+
 }

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1706,4 +1706,27 @@ fn test() {
         check_program(vec![mod1]).unwrap();
     }
 
+    #[test]
+    fn bind_fn_type_app_mod_access() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}";
+
+        let mod2 =
+"mod mod2;
+
+use mod1;
+
+fn test() {
+    let my_ident: fn(int) -> int = mod1::ident(type int);
+    let result: int = my_ident(5);
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let mod2 = parse_module(wrap_input!(mod2)).unwrap();
+        check_program(vec![mod1, mod2]).unwrap();
+    }
 }

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1729,4 +1729,27 @@ fn test() {
         let mod2 = parse_module(wrap_input!(mod2)).unwrap();
         check_program(vec![mod1, mod2]).unwrap();
     }
+
+    #[test]
+    fn bind_fn_type_app_mod_access_stmt() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}";
+
+        let mod2 =
+"mod mod2;
+
+use mod1;
+
+fn test() {
+    mod1::ident(type int);
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let mod2 = parse_module(wrap_input!(mod2)).unwrap();
+        check_program(vec![mod1, mod2]).unwrap();
+    }
 }

--- a/smpl/src/parser/parser_tests.rs
+++ b/smpl/src/parser/parser_tests.rs
@@ -703,4 +703,21 @@ struct Bar(type T)
 
         let _mod1 = parse_module(wrap_input!(mod1)).unwrap();
     }
+
+    #[test]
+    fn parse_bind_fn_type_app() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}
+
+fn test() {
+    let my_ident: fn(int) -> int = ident(type int);
+    let result: int = my_ident(5);
+}";
+
+        let _mod1 = parse_module(wrap_input!(mod1)).unwrap();
+    }
 }

--- a/smpl/src/parser/parser_tests.rs
+++ b/smpl/src/parser/parser_tests.rs
@@ -720,4 +720,27 @@ fn test() {
 
         let _mod1 = parse_module(wrap_input!(mod1)).unwrap();
     }
+
+    #[test]
+    fn parse_bind_fn_type_app_mod_access() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}";
+
+        let mod2 =
+"mod mod2;
+
+use mod1;
+
+fn test() {
+    let my_ident: fn(int) -> int = mod1::ident(type int);
+    let result: int = my_ident(5);
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let mod2 = parse_module(wrap_input!(mod2)).unwrap();
+    }
 }

--- a/smpl/src/parser/parser_tests.rs
+++ b/smpl/src/parser/parser_tests.rs
@@ -743,4 +743,26 @@ fn test() {
         let mod1 = parse_module(wrap_input!(mod1)).unwrap();
         let mod2 = parse_module(wrap_input!(mod2)).unwrap();
     }
+
+    #[test]
+    fn parse_bind_fn_type_app_mod_access_stmt() {
+        let mod1 =
+"mod mod1;
+
+fn ident(type T)(t: T) -> T {
+    return t;
+}";
+
+        let mod2 =
+"mod mod2;
+
+use mod1;
+
+fn test() {
+    mod1::ident(type int);
+}";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        let mod2 = parse_module(wrap_input!(mod2)).unwrap();
+    }
 }

--- a/smpli/src/vm_tests.rs
+++ b/smpli/src/vm_tests.rs
@@ -596,7 +596,7 @@ fn foo() -> int {
 }
 
 #[test]
-fn bind_fn_type_app_mod_access() {
+fn interpreter_bind_fn_type_app_mod_access() {
     let mod1 =
 "mod mod1;
 


### PR DESCRIPTION
Typed paths were not being allowed in positions duringa module access where function calls could be found.

For example, the following is legal SMPL but failed to parse correctly:

```
use modX;
...
let f: fn(int) -> int = modX::ident(type int);
```