### PR TITLE
SMPLI Builtin 'vec' Improvements

### DIFF
--- a/smpli/src/builtins/vec.rs
+++ b/smpli/src/builtins/vec.rs
@@ -416,4 +416,27 @@ return vec::contains(type int)(v, 20);
 
     assert_eq!(Value::Bool(false), result);
 }
+
+#[test]
+fn interpreter_vec_clear() {
+    let mod1 =
+"
+mod mod1;
+use vec;
+
+fn test() -> int {
+let v = vec::new(type int)();
+v = vec::push(type int)(v, 123);
+v = vec::push(type int)(v, 456);
+
+let cleared = vec::clear(type int)(v);
+
+return vec::len(type int)(cleared);
+}
+";
+
+    let result = vec_test!(mod1, "mod1", "test", None);
+
+    assert_eq!(Value::Int(0), result);
+}
 }

--- a/smpli/src/builtins/vec.smpl
+++ b/smpli/src/builtins/vec.smpl
@@ -10,3 +10,4 @@ builtin fn push(type T)(v: Vec(type T), val: T) -> Vec(type T);
 builtin fn insert(type T)(v: Vec(type T), i: int, val: T) -> Vec(type T);
 builtin fn get(type T)(v: Vec(type T), i: int) -> T;
 builtin fn remove(type T)(v: Vec(type T), i: int) -> Vec(type T);
+builtin fn clear(type T)(v: Vec(type T)) -> Vec(type T);

--- a/smpli/src/builtins/vec.smpl
+++ b/smpli/src/builtins/vec.smpl
@@ -1,5 +1,7 @@
 mod vec;
 
+use option;
+
 #[opaque]
 struct Vec(type T) { }
 
@@ -8,6 +10,7 @@ builtin fn len(type T)(v: Vec(type T)) -> int;
 builtin fn contains(type T)(v: Vec(type T), val: T) -> bool;
 builtin fn push(type T)(v: Vec(type T), val: T) -> Vec(type T);
 builtin fn insert(type T)(v: Vec(type T), i: int, val: T) -> Vec(type T);
-builtin fn get(type T)(v: Vec(type T), i: int) -> T;
+builtin fn get_value(type T)(v: Vec(type T), i: int) -> T;
+builtin fn get(type T)(v: Vec(type T), i: int) -> option::Option(type T);
 builtin fn remove(type T)(v: Vec(type T), i: int) -> Vec(type T);
 builtin fn clear(type T)(v: Vec(type T)) -> Vec(type T);

--- a/smpli/src/std_options.rs
+++ b/smpli/src/std_options.rs
@@ -59,7 +59,7 @@ impl Std {
         include!(v, self, math, builtins::math::vm_module());
         include!(v, self, str, builtins::str::vm_module());
         include!(v, self, option, builtins::option::vm_module());
-        include!(v, self, vec, builtins::option::vm_module());
+        include!(v, self, vec, builtins::vec::vm_module());
 
         // vec requires option
         if !self.option {

--- a/smpli/src/std_options.rs
+++ b/smpli/src/std_options.rs
@@ -23,6 +23,8 @@ pub struct Std {
     str: bool,
     #[builder(default = "false")]
     option: bool,
+    #[builder(default = "false")]
+    vec: bool,
 }
 
 impl Std {
@@ -34,6 +36,7 @@ impl Std {
             math: true,
             str: true,
             option: true,
+            vec: true,
         }
     }
 
@@ -45,6 +48,7 @@ impl Std {
             math: false,
             str: false,
             option: false,
+            vec: false,
         }
     }
 
@@ -55,5 +59,9 @@ impl Std {
         include!(v, self, math, builtins::math::vm_module());
         include!(v, self, str, builtins::str::vm_module());
         include!(v, self, option, builtins::option::vm_module());
+        include!(v, self, vec, builtins::option::vm_module());
+
+        // vec requires option
+        include!(v, self, vec, builtins::option::vm_module());
     }
 }

--- a/smpli/src/std_options.rs
+++ b/smpli/src/std_options.rs
@@ -62,6 +62,8 @@ impl Std {
         include!(v, self, vec, builtins::option::vm_module());
 
         // vec requires option
-        include!(v, self, vec, builtins::option::vm_module());
+        if !self.option {
+            include!(v, self, vec, builtins::option::vm_module());
+        }
     }
 }


### PR DESCRIPTION
Add 'vec' as a loadable standard module.

Add `vec::clear()`.

Split `vec::get()` into `vec::get()` and `vec::get_value()`
`vec::get()` returns an `option::Option` while `vec::get_value()` returns the value or throws a runtime error.