### PR TITLE
Smpl Top-Level Name Checking

### DIFF
--- a/smpl/src/analysis/error.rs
+++ b/smpl/src/analysis/error.rs
@@ -15,6 +15,7 @@ pub enum AnalysisError {
     UnresolvedUses(Vec<AstNode<UseDecl>>),
     UnresolvedStructs(Vec<AstNode<Struct>>),
     UnresolvedFns(Vec<AstNode<Function>>),
+    TopLevelError(TopLevelError),
     MissingModName,
     Errors(Vec<AnalysisError>),
 }
@@ -36,6 +37,18 @@ impl From<AnalysisError> for Error {
     fn from(e: AnalysisError) -> Error {
         Error::AnalysisError(format!("{:?}", e))
     }
+}
+
+impl From<TopLevelError> for AnalysisError {
+    fn from(t: TopLevelError) -> AnalysisError {
+        AnalysisError::TopLevelError(t)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TopLevelError {
+    DuplicateTypes(Ident),
+    DuplicateFns(Ident),
 }
 
 #[derive(Clone, Debug)]

--- a/smpl/src/analysis/semantic_ck.rs
+++ b/smpl/src/analysis/semantic_ck.rs
@@ -1845,4 +1845,142 @@ fn bar() {
             }
         }
     }
+
+    #[test]
+    fn top_level_name_collision_struct() {
+        let mod1 =
+"mod mod1;
+
+struct Foo { }
+
+struct Foo { }";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_name_collision_struct_opaque() {
+        let mod1 =
+"mod mod1;
+
+struct Foo { }
+
+opaque Foo;";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_name_collision_opaque() {
+        let mod1 =
+"mod mod1;
+
+opaque Foo;
+
+opaque Foo;";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_name_collision_fn() {
+        let mod1 =
+"mod mod1;
+
+fn Foo() { }
+
+fn Foo() { }";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_name_collision_fn_builtin() {
+        let mod1 =
+"mod mod1;
+
+fn Foo() { }
+
+builtin fn Foo();";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn top_level_name_collision_builtin_fn() {
+        let mod1 =
+"mod mod1;
+
+builtin fn Foo();
+
+builtin fn Foo();";
+
+        let mod1 = parse_module(wrap_input!(mod1)).unwrap();
+        match check_program(vec![mod1]) {
+            Ok(_) => panic!("Expected an error. Found OK"),
+
+            Err(e) => {
+                if let AnalysisError::TopLevelError(_) = e {
+                    ()
+                } else {
+                    panic!("Expected a top level error. Found {:?}", e);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Check top-level declarations for naming conflicts.

Type declarations may conflict with other type declarations.
Function declarations may conflict with function declarations.

Type declarations do not conflict with function declarations such that the following passes static checks:

```
struct Foo { }
fn Foo() { }
```