### PR TITLE
smpl 0.16.0

### DIFF
--- a/smpl/Cargo.toml
+++ b/smpl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smpl"
-version = "0.15.2"
+version = "0.16.0"
 authors = ["Alexander Vo <randomcivvy0121@gmail.com>"]
 workspace = ".."
 edition = "2018"

--- a/smpl/src/analysis/analysis_helpers.rs
+++ b/smpl/src/analysis/analysis_helpers.rs
@@ -11,13 +11,15 @@ use super::resolve_scope::ScopedData;
 use super::type_checker::TypingContext;
 use super::type_cons::*;
 
-pub fn analyze_fn(universe: &mut Universe, fn_id: FnId) -> Result<(), AnalysisError> {
+pub fn analyze_fn(universe: &mut Universe, metadata: &mut Metadata, fn_id: FnId) 
+    -> Result<(), AnalysisError> {
+
     use super::resolve_scope;
     use super::type_checker;
     use super::return_trace;
 
     resolve_scope::resolve(universe, fn_id)?;
-    type_checker::type_check(universe, fn_id)?;
+    type_checker::type_check(universe, metadata, fn_id)?;
     return_trace::return_trace(universe, fn_id)?;
 
     Ok(())

--- a/smpl/src/analysis/mod.rs
+++ b/smpl/src/analysis/mod.rs
@@ -29,3 +29,4 @@ pub use self::semantic_ck::check_program;
 pub use self::semantic_data::*;
 pub use self::semantic_data::{Function, Module, Program};
 pub use self::typed_ast::*;
+pub use self::type_checker::TypingContext;

--- a/smpl/src/analysis/mod_resolver.rs
+++ b/smpl/src/analysis/mod_resolver.rs
@@ -193,10 +193,11 @@ pub fn check_modules(
     }
 
     for (mod_id, raw_mod) in raw_data.iter() {
+        let (universe, metadata, _) = program.analysis_context();
         for (_, reserved_fn) in raw_mod.reserved_fns.iter() {
             let fn_id = reserved_fn.0;
 
-            analysis_helpers::analyze_fn(program.universe_mut(), fn_id)?;
+            analysis_helpers::analyze_fn(universe, metadata, fn_id)?;
         }
     }
 

--- a/smpl/src/analysis/mod_resolver.rs
+++ b/smpl/src/analysis/mod_resolver.rs
@@ -119,8 +119,12 @@ pub fn check_modules(
             let fn_decl = reserved_fn.1.data();
             let fn_name = fn_decl.name.data();
             // TODO: Store new function scope storing the type parameters
+            
+            let (universe, metadata, _) = program.analysis_context();
+
             let fn_type_cons = type_cons_gen::generate_fn_type_cons(
-                program.universe(),
+                universe,
+                metadata,
                 raw_program.scopes.get(mod_id).unwrap(),
                 &TypingContext::empty(),
                 fn_id,
@@ -128,7 +132,7 @@ pub fn check_modules(
             )?;
 
             let analysis_context = analysis_helpers::generate_fn_analysis_data(
-                program.universe(),
+                universe,
                 raw_program.scopes.get(mod_id).unwrap(),
                 &TypingContext::empty(),
                 &fn_type_cons,

--- a/smpl/src/analysis/semantic_data.rs
+++ b/smpl/src/analysis/semantic_data.rs
@@ -513,7 +513,7 @@ impl SMPLFunction {
         self.cfg.clone()
     }
 
-    pub(super) fn analysis_context(&self) -> &AnalysisContext {
+    pub(crate) fn analysis_context(&self) -> &AnalysisContext {
         &self.analysis_context
     }
 

--- a/smpl/src/analysis/semantic_data.rs
+++ b/smpl/src/analysis/semantic_data.rs
@@ -414,6 +414,10 @@ impl AnalysisContext {
         &self.typing_context
     }
 
+    pub fn set_typing_context(&mut self, tc: TypingContext) {
+        self.typing_context = tc;
+    }
+
     pub fn existential_type_vars(&self) -> &[TypeVarId] {
         &self.existential_type_vars
     }
@@ -511,6 +515,10 @@ impl SMPLFunction {
 
     pub(super) fn analysis_context(&self) -> &AnalysisContext {
         &self.analysis_context
+    }
+
+    pub(super) fn analysis_context_mut(&mut self) -> &mut AnalysisContext {
+        &mut self.analysis_context
     }
 }
 

--- a/smpl/src/analysis/semantic_data.rs
+++ b/smpl/src/analysis/semantic_data.rs
@@ -52,6 +52,23 @@ impl Program {
         self.universe.all_fns()
     }
 
+    pub fn smpl_fns(&self) -> impl Iterator<Item=(FnId, &SMPLFunction)> {
+        self.universe
+            .all_fns()
+            .filter(|(_, f)| {
+                match f {
+                    Function::SMPL(_) => true,
+                    _ => false
+                }
+            })
+            .map(|(f_id, f)| {
+                match f {
+                    Function::SMPL(f) => (f_id, f),
+                    _ => unreachable!(),
+                }
+            })
+    }
+
     pub fn metadata(&self) -> &Metadata {
         &self.metadata
     }

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -1117,7 +1117,9 @@ fn resolve_indexing(universe: &Universe, scope: &ScopedData, context: &TypingCon
             AbstractType::Array {
                 ref element_type,
                 ..
-            } => *(element_type.clone()),
+            } => {
+                element_type.substitute(universe, scope, context)?
+            },
 
             _ => {
                 return Err(TypeError::NotAnArray {

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -422,9 +422,16 @@ impl TypingContext {
             tmp_type_map: HashMap::new(),
         }
     }
+
     pub fn get_type_var(&self, id: TypeVarId) -> Option<&AbstractType> {
         self.type_vars
             .get(&id)
+    }
+
+    pub fn tmp_type(&self, tmp_id: TmpId) -> &AbstractType  {
+        self.tmp_type_map
+            .get(&tmp_id)
+            .expect("Missing type for tmp")
     }
 }
 

--- a/smpl/src/analysis/type_cons_gen.rs
+++ b/smpl/src/analysis/type_cons_gen.rs
@@ -223,6 +223,7 @@ pub fn generate_builtin_fn_type(
 
 pub fn generate_anonymous_fn_type(
     universe: &Universe,
+    metadata: &mut Metadata,
     outer_scope: &ScopedData,
     outer_context: &TypingContext,
     fn_id: FnId,
@@ -246,6 +247,7 @@ pub fn generate_anonymous_fn_type(
         None => AbstractType::Unit,
     };
 
+    let mut param_metadata = Vec::new();
     let typed_formal_params = match fn_def.params {
         Some(ref params) => {
             let mut typed_formal_params = Vec::new();
@@ -258,6 +260,11 @@ pub fn generate_anonymous_fn_type(
                     type_from_ann(universe, &type_param_scope, &type_param_typing_context, param_ann)?;
 
                 typed_formal_params.push(param_type);
+
+                param_metadata.push(FunctionParameter::new(
+                        param.name.data().clone(),
+                        universe.new_var_id(),
+                    ));
             }
 
             typed_formal_params
@@ -265,6 +272,8 @@ pub fn generate_anonymous_fn_type(
 
         None => Vec::new(),
     };
+
+    metadata.insert_function_param_ids(fn_id, param_metadata);
 
     Ok(TypeCons::Function {
         type_params: type_params,

--- a/smpl/src/analysis/type_cons_gen.rs
+++ b/smpl/src/analysis/type_cons_gen.rs
@@ -72,6 +72,7 @@ pub fn generate_struct_type_cons(
 }
 
 pub fn generate_fn_type_cons(universe: &Universe,
+    metadata: &mut Metadata,
     outer_scope: &ScopedData,
     outer_context: &TypingContext,
     fn_id: FnId,
@@ -95,6 +96,7 @@ pub fn generate_fn_type_cons(universe: &Universe,
         None => AbstractType::Unit,
     };
 
+    let mut param_metadata = Vec::new();
     let typed_formal_params = match fn_def.params {
         Some(ref params) => {
             let mut typed_formal_params = Vec::new();
@@ -107,13 +109,21 @@ pub fn generate_fn_type_cons(universe: &Universe,
                     type_from_ann(universe, &type_param_scope, &type_param_typing_context, param_ann)?;
 
                 typed_formal_params.push(param_type);
+
+                param_metadata.push(FunctionParameter::new(
+                        param.name.data().clone(),
+                        universe.new_var_id(),
+                    ));
             }
+
 
             typed_formal_params
         },
 
         None => Vec::new(),
     };
+
+    metadata.insert_function_param_ids(fn_id, param_metadata);
 
     Ok(TypeCons::Function {
         type_params: type_params,

--- a/smpl/src/analysis/typed_ast.rs
+++ b/smpl/src/analysis/typed_ast.rs
@@ -14,13 +14,14 @@ use super::expr_flow;
 use super::semantic_data::*;
 use super::type_cons::*;
 
+// TODO(alex): Remove Typed<T>
+// Types are stored within type_checker::TypingContext instead
 #[derive(Debug, Clone)]
 pub struct Typed<T>
 where
     T: ::std::fmt::Debug + Clone,
 {
     data: T,
-    data_type: Option<AbstractType>,
 }
 
 impl<T> Typed<T>
@@ -38,28 +39,7 @@ where
     pub fn untyped(data: T) -> Typed<T> {
         Typed {
             data: data,
-            data_type: None,
         }
-    }
-
-    pub fn typed(data: T, t: AbstractType) -> Typed<T> {
-        Typed {
-            data: data,
-            data_type: Some(t),
-        }
-    }
-
-    pub fn set_type(&mut self, t: AbstractType) {
-        // TODO: Handle type override
-        if self.data_type.is_some() {
-            panic!("Attempting to overwrite the type of this node ({:?})", self);
-        } else {
-            self.data_type = Some(t);
-        }
-    }
-
-    pub fn get_type(&self) -> Option<AbstractType> {
-        self.data_type.clone()
     }
 }
 
@@ -227,7 +207,6 @@ impl Expr {
             id: universe.new_tmp_id(),
             value: Typed {
                 data: val,
-                data_type: None,
             },
             span: span,
         };
@@ -630,26 +609,12 @@ impl self::Path {
         }
     }
 
-    pub fn root_var_type(&self) -> AbstractType {
-        match self.root_var {
-            Some(ref typed_var_id) => typed_var_id.get_type().unwrap().clone(),
-            None => panic!("No root var"),
-        }
-    }
-
     pub fn set_root_var(&mut self, id: VarId) {
         if self.root_var.is_some() {
             panic!("Attempting to overwrite root VarId");
         }
 
         self.root_var = Some(Typed::untyped(id));
-    }
-
-    pub fn set_root_var_type(&mut self, ty: AbstractType) {
-        match self.root_var {
-            Some(ref mut t) => t.set_type(ty),
-            None => panic!("No root var"),
-        }
     }
 
     pub fn path(&self) -> &[self::PathSegment] {
@@ -688,26 +653,12 @@ impl Field {
         }
     }
 
-    pub fn field_type(&self) -> AbstractType {
-        match self.field_id {
-            Some(ref typed_field_id) => typed_field_id.get_type().unwrap().clone(),
-            None => panic!("No field"),
-        }
-    }
-
     pub fn set_field_id(&mut self, id: FieldId) {
         if self.field_id.is_some() {
             panic!("Attempting to override field id.");
         }
 
         self.field_id = Some(Typed::untyped(id));
-    }
-
-    pub fn set_field_type(&mut self, app: AbstractType) {
-        match self.field_id {
-            Some(ref mut t) => t.set_type(app),
-            None => panic!("No field"),
-        }
     }
 }
 

--- a/smpl/src/code_gen/byte_gen/byte_expr.rs
+++ b/smpl/src/code_gen/byte_gen/byte_expr.rs
@@ -109,7 +109,7 @@ fn translate_tmp(tmp: &Tmp, typing_context: &TypingContext) -> Vec<Instruction> 
             }
 
             let ty = typing_context
-                .tmp_type(tmp.id());
+                .tmp_type(*lhs.data());
             let lhs = Arg::Location(Location::Tmp(tmp_id(*lhs.data())));
             let rhs = Arg::Location(Location::Tmp(tmp_id(*rhs.data())));
             match op {

--- a/smpl/src/code_gen/byte_gen/mod.rs
+++ b/smpl/src/code_gen/byte_gen/mod.rs
@@ -6,7 +6,7 @@ mod third_pass;
 
 use std::fmt;
 
-use crate::analysis::SMPLFunction;
+use crate::program::CompilableFn;
 
 pub use byte_code::{
     Instruction,
@@ -71,7 +71,7 @@ impl fmt::Display for ByteCodeFunction {
 }
 
 /// Takes a CFG and transforms it into valid and executable bytecode
-pub fn compile_to_byte_code(function: &SMPLFunction) -> ByteCodeFunction {
+pub fn compile_to_byte_code(function: &CompilableFn) -> ByteCodeFunction {
 
     let cfg = function.cfg();
     let cfg = cfg.borrow();

--- a/smpl/src/code_gen/byte_gen/mod.rs
+++ b/smpl/src/code_gen/byte_gen/mod.rs
@@ -75,10 +75,11 @@ pub fn compile_to_byte_code(function: &CompilableFn) -> ByteCodeFunction {
 
     let cfg = function.cfg();
     let cfg = cfg.borrow();
+    let typing_context = function.typing_context();
 
     // Goes through the CFG and collects the main function body, loops, and branches
     //   into organized groups of instructions with metadata
-    let mut first_pass = first_pass::FirstPass::new();
+    let mut first_pass = first_pass::FirstPass::new(typing_context);
     {
         let traverser = Traverser::new(&*cfg, &mut first_pass);
 

--- a/smpl/src/lib.rs
+++ b/smpl/src/lib.rs
@@ -31,4 +31,4 @@ pub use crate::analysis::{ metadata };
 
 pub use crate::code_gen::byte_gen;
 
-pub use crate::program::Program;
+pub use crate::program::{ CompilableFn, Program };

--- a/smpl/src/lib.rs
+++ b/smpl/src/lib.rs
@@ -19,6 +19,7 @@ mod analysis;
 mod code_gen;
 mod module;
 mod span;
+mod program;
 
 pub use self::err::Error;
 pub use self::module::{ParsedModule, UnparsedModule};
@@ -26,6 +27,8 @@ pub use self::module::{ParsedModule, UnparsedModule};
 pub use self::parser::parse_module;
 pub use crate::analysis::{ TypeId, FnId, ModuleId };
 
-pub use crate::analysis::{ Program, check_program, metadata };
+pub use crate::analysis::{ metadata };
 
 pub use crate::code_gen::byte_gen;
+
+pub use crate::program::Program;

--- a/smpl/src/program.rs
+++ b/smpl/src/program.rs
@@ -16,6 +16,10 @@ impl Program {
         })
     }
 
+    pub fn metadata(&self) -> &crate::metadata::Metadata {
+        &self.program.metadata()
+    }
+
     pub fn compilable_fns<'a>(&'a self) 
         -> impl Iterator<Item=(FnId, CompilableFn)> + 'a {
 

--- a/smpl/src/program.rs
+++ b/smpl/src/program.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::module::ParsedModule;
-use crate::analysis::{ check_program, Program as AnalyzedProgram, Function, CFG, FnId, AnonymousFunction };
+use crate::analysis::{ check_program, Program as AnalyzedProgram, Function, CFG, FnId, AnonymousFunction, TypingContext };
 use crate::analysis::error::AnalysisError;
 
 pub struct Program {
@@ -36,7 +36,8 @@ impl Program {
                 match f {
                     Function::SMPL(f) => {
                         let c_fn = CompilableFn {
-                            cfg: f.cfg()
+                            cfg: f.cfg(),
+                            typing_context: f.analysis_context().typing_context(),
                         };
                         (f_id, c_fn)
                     },
@@ -47,10 +48,12 @@ impl Program {
 
                     Function::Anonymous(AnonymousFunction::Resolved {
                         ref cfg,
+                        ref analysis_context,
                         ..
                     }) => {
                         let c_fn = CompilableFn {
-                            cfg: cfg.clone()
+                            cfg: cfg.clone(),
+                            typing_context: analysis_context.typing_context()
                         };
 
                         (f_id, c_fn)
@@ -62,12 +65,17 @@ impl Program {
     }
 }
 
-pub struct CompilableFn {
-    cfg: Rc<RefCell<CFG>>
+pub struct CompilableFn<'a> {
+    cfg: Rc<RefCell<CFG>>,
+    typing_context: &'a TypingContext,
 }
 
-impl CompilableFn {
+impl<'a> CompilableFn<'a> {
     pub(crate) fn cfg(&self) -> &Rc<RefCell<CFG>> {
         &self.cfg
+    }
+
+    pub(crate) fn typing_context(&self) -> &TypingContext {
+        self.typing_context
     }
 }

--- a/smpli/Cargo.toml
+++ b/smpli/Cargo.toml
@@ -10,7 +10,7 @@ license="MIT"
 repository="https://github.com/InnPatron/smpl"
 
 [dependencies]
-smpl = "0.15.2"
+smpl = "0.16.0"
 irmatch = "0.2.0"
 failure = "0.1.2"
 failure_derive = "0.1.2"

--- a/smpli/Cargo.toml
+++ b/smpli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smpli"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Alexander Vo <randomcivvy0121@gmail.com>"]
 edition = "2018"
 

--- a/smpli/src/builtins/option.smpl
+++ b/smpli/src/builtins/option.smpl
@@ -1,7 +1,6 @@
 mod option;
 
-#[opaque]
-struct Option(type T) { }
+opaque Option(type T);
 
 builtin fn some(type T)(value: T) -> Option(type T);
 builtin fn is_some(type T)(value: Option(type T)) -> bool;

--- a/smpli/src/builtins/vec.smpl
+++ b/smpli/src/builtins/vec.smpl
@@ -2,8 +2,7 @@ mod vec;
 
 use option;
 
-#[opaque]
-struct Vec(type T) { }
+opaque Vec(type T);
 
 builtin fn new(type T)() -> Vec(type T);
 builtin fn len(type T)(v: Vec(type T)) -> int;

--- a/smpli/src/vm.rs
+++ b/smpli/src/vm.rs
@@ -44,11 +44,11 @@ impl AVM {
             })
             .collect();
 
-        let program = smpl::check_program(modules)?;
+        let program = smpl::Program::create(modules)?;
 
         let mut compiled_fns = HashMap::new();
-        for (fn_id, raw_fn_ref) in program.all_fns() {
-            let compiled = byte_gen::compile_to_byte_code(raw_fn_ref);
+        for (fn_id, raw_fn_ref) in program.compilable_fns() {
+            let compiled = byte_gen::compile_to_byte_code(&raw_fn_ref);
             if compiled_fns.insert(fn_id, Arc::new(compiled)).is_some() {
                 panic!("Multiple functions with ID {}. Should not have passed check_program()", fn_id);
             }


### PR DESCRIPTION
- Native syntax and type support for opaque types
- Add checks for top-level name collisions
- smpl API changes
- Update smpli
- smpl internal rewrite
  - Simpler type system abstractions
  - Fixes type soundness issues
- Bug fixes