### PR TITLE
SMPLI Future

### DIFF
--- a/examples/tic-tac-toe/src/main.rs
+++ b/examples/tic-tac-toe/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
 fn execute(vm: AVM) {
     let fn_handle = vm.query_module("rt", "run").unwrap().unwrap(); 
     let executor = match vm
-        .spawn_executor(fn_handle, None, SpawnOptions {
+        .spawn_executor(fn_handle, vec![], SpawnOptions {
             type_check: false
         }) {
 

--- a/examples/tic-tac-toe/src/rt.rs
+++ b/examples/tic-tac-toe/src/rt.rs
@@ -8,10 +8,10 @@ const RT: &'static str = include_str!("rt.smpl");
 
 pub fn vm_module() -> VmModule {
     VmModule::new(parse_module(UnparsedModule::anonymous(RT)).unwrap())
-        .add_builtin("user_key", user_input)
+        .add_builtin("user_key", smpli::erase(user_input))
 }
 
-fn user_input(_args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn user_input(_args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut input = String::new();
     let size = io::stdin().read_line(&mut input).unwrap();
 

--- a/examples/tic-tac-toe/src/rt.rs
+++ b/examples/tic-tac-toe/src/rt.rs
@@ -11,7 +11,7 @@ pub fn vm_module() -> VmModule {
         .add_builtin("user_key", smpli::erase(user_input))
 }
 
-async fn user_input(_args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn user_input(_args: Vec<Value>) -> smpli::BuiltinResult {
     let mut input = String::new();
     let size = io::stdin().read_line(&mut input).unwrap();
 

--- a/smpli/Cargo.toml
+++ b/smpli/Cargo.toml
@@ -18,3 +18,4 @@ failure_derive = "0.1.2"
 uuid = { version = "0.7", features = ["v4"] }
 derive_builder = "0.7.0"
 paste = "0.1.6"
+futures = "0.3.1"

--- a/smpli/Cargo.toml
+++ b/smpli/Cargo.toml
@@ -17,3 +17,4 @@ failure = "0.1.2"
 failure_derive = "0.1.2"
 uuid = { version = "0.7", features = ["v4"] }
 derive_builder = "0.7.0"
+paste = "0.1.6"

--- a/smpli/src/builtins/convert.rs
+++ b/smpli/src/builtins/convert.rs
@@ -22,12 +22,12 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(CONVERT_INT_TO_FLOAT,      boxed_int_to_float)
-        .add_builtin(CONVERT_FLOAT_TO_INT,      boxed_float_to_int)
-        .add_builtin(CONVERT_IS_FLOAT,          boxed_is_float)
-        .add_builtin(CONVERT_IS_INT,            boxed_is_int)
-        .add_builtin(CONVERT_STRING_TO_FLOAT,   boxed_string_to_float)
-        .add_builtin(CONVERT_STRING_TO_INT,     boxed_string_to_int);
+        .add_builtin(CONVERT_INT_TO_FLOAT,      super::erase(int_to_float))
+        .add_builtin(CONVERT_FLOAT_TO_INT,      super::erase(float_to_int))
+        .add_builtin(CONVERT_IS_FLOAT,          super::erase(is_float))
+        .add_builtin(CONVERT_IS_INT,            super::erase(is_int))
+        .add_builtin(CONVERT_STRING_TO_FLOAT,   super::erase(string_to_float))
+        .add_builtin(CONVERT_STRING_TO_INT,     super::erase(string_to_int));
 
     module
 }
@@ -45,13 +45,6 @@ pub enum ConversionTarget {
     #[fail(display = "Float")]
     Float,
 }
-
-async_box!(int_to_float);
-async_box!(float_to_int);
-async_box!(is_float);
-async_box!(is_int);
-async_box!(string_to_float);
-async_box!(string_to_int);
 
 async fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;

--- a/smpli/src/builtins/convert.rs
+++ b/smpli/src/builtins/convert.rs
@@ -22,12 +22,12 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(CONVERT_INT_TO_FLOAT, int_to_float)
-        .add_builtin(CONVERT_FLOAT_TO_INT, float_to_int)
-        .add_builtin(CONVERT_IS_FLOAT, is_float)
-        .add_builtin(CONVERT_IS_INT, is_int)
-        .add_builtin(CONVERT_STRING_TO_FLOAT, string_to_float)
-        .add_builtin(CONVERT_STRING_TO_INT, string_to_int);
+        .add_builtin(CONVERT_INT_TO_FLOAT,      boxed_int_to_float)
+        .add_builtin(CONVERT_FLOAT_TO_INT,      boxed_float_to_int)
+        .add_builtin(CONVERT_IS_FLOAT,          boxed_is_float)
+        .add_builtin(CONVERT_IS_INT,            boxed_is_int)
+        .add_builtin(CONVERT_STRING_TO_FLOAT,   boxed_string_to_float)
+        .add_builtin(CONVERT_STRING_TO_INT,     boxed_string_to_int);
 
     module
 }
@@ -46,7 +46,14 @@ pub enum ConversionTarget {
     Float,
 }
 
-fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async_box!(int_to_float);
+async_box!(float_to_int);
+async_box!(is_float);
+async_box!(is_int);
+async_box!(string_to_float);
+async_box!(string_to_int);
+
+async fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -56,7 +63,7 @@ fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn float_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn float_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -66,7 +73,7 @@ fn float_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn is_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn is_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -76,7 +83,7 @@ fn is_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn is_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn is_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -86,7 +93,7 @@ fn is_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn string_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn string_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -100,7 +107,7 @@ fn string_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn string_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn string_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);

--- a/smpli/src/builtins/convert.rs
+++ b/smpli/src/builtins/convert.rs
@@ -46,7 +46,7 @@ pub enum ConversionTarget {
     Float,
 }
 
-async fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn int_to_float(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -56,7 +56,7 @@ async fn int_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn float_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn float_to_int(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -66,7 +66,7 @@ async fn float_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn is_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn is_float(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -76,7 +76,7 @@ async fn is_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn is_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn is_int(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -86,7 +86,7 @@ async fn is_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn string_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn string_to_float(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);
@@ -100,7 +100,7 @@ async fn string_to_float(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn string_to_int(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn string_to_int(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let a = args.remove(0);

--- a/smpli/src/builtins/err.rs
+++ b/smpli/src/builtins/err.rs
@@ -16,9 +16,9 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(ERR_PANIC,     boxed_panic)
-        .add_builtin(ERR_PANIC_MSG, boxed_panic_msg)
-        .add_builtin(ERR_ASSERT,    boxed_assert);
+        .add_builtin(ERR_PANIC,     super::erase(panic))
+        .add_builtin(ERR_PANIC_MSG, super::erase(panic_msg))
+        .add_builtin(ERR_ASSERT,    super::erase(assert));
 
     module
 }
@@ -34,11 +34,6 @@ impl std::fmt::Display for RuntimeError {
         }
     }
 }
-
-
-async_box!(panic);
-async_box!(panic_msg);
-async_box!(assert);
 
 async fn panic(_args: Option<Vec<Value>>) -> Result<Value, Error> {
     Err(RuntimeError(None))?

--- a/smpli/src/builtins/err.rs
+++ b/smpli/src/builtins/err.rs
@@ -35,12 +35,11 @@ impl std::fmt::Display for RuntimeError {
     }
 }
 
-async fn panic(_args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn panic(_args: Vec<Value>) -> Result<Value, Error> {
     Err(RuntimeError(None))?
 }
 
-async fn panic_msg(args: Option<Vec<Value>>) -> Result<Value, Error> {
-    let mut args = args.unwrap();
+async fn panic_msg(mut args: Vec<Value>) -> Result<Value, Error> {
     let a = args.remove(0);
 
     match a {
@@ -49,8 +48,7 @@ async fn panic_msg(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn assert(args: Option<Vec<Value>>) -> Result<Value, Error> {
-    let mut args = args.unwrap();
+async fn assert(mut args: Vec<Value>) -> Result<Value, Error> {
     let a = args.remove(0);
 
     let a = irmatch!(a; Value::Bool(a) => a);

--- a/smpli/src/builtins/err.rs
+++ b/smpli/src/builtins/err.rs
@@ -16,9 +16,9 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(ERR_PANIC, panic)
-        .add_builtin(ERR_PANIC_MSG, panic_msg)
-        .add_builtin(ERR_ASSERT, assert);
+        .add_builtin(ERR_PANIC,     boxed_panic)
+        .add_builtin(ERR_PANIC_MSG, boxed_panic_msg)
+        .add_builtin(ERR_ASSERT,    boxed_assert);
 
     module
 }
@@ -35,11 +35,16 @@ impl std::fmt::Display for RuntimeError {
     }
 }
 
-fn panic(_args: Option<Vec<Value>>) -> Result<Value, Error> {
+
+async_box!(panic);
+async_box!(panic_msg);
+async_box!(assert);
+
+async fn panic(_args: Option<Vec<Value>>) -> Result<Value, Error> {
     Err(RuntimeError(None))?
 }
 
-fn panic_msg(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn panic_msg(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = args.unwrap();
     let a = args.remove(0);
 
@@ -49,7 +54,7 @@ fn panic_msg(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn assert(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn assert(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = args.unwrap();
     let a = args.remove(0);
 

--- a/smpli/src/builtins/log.rs
+++ b/smpli/src/builtins/log.rs
@@ -15,8 +15,8 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(LOG_PRINT, print)
-        .add_builtin(LOG_PRINTLN, println);
+        .add_builtin(LOG_PRINT,   boxed_print)
+        .add_builtin(LOG_PRINTLN, boxed_println);
 
     module
 }
@@ -25,7 +25,10 @@ pub fn vm_module() -> VmModule {
 #[fail(display = "Logging Error: '{}'", _0)]
 pub struct LoggingError(std::io::Error);
 
-fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async_box!(print);
+async_box!(println);
+
+async fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = min_args!(1, args)?;
 
     for arg in args {
@@ -37,7 +40,7 @@ fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Unit)
 }
 
-fn println(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn println(args: Option<Vec<Value>>) -> Result<Value, Error> {
     if let Some(args) = args {
         for arg in args {
             print!("{}", arg);

--- a/smpli/src/builtins/log.rs
+++ b/smpli/src/builtins/log.rs
@@ -25,7 +25,7 @@ pub fn vm_module() -> VmModule {
 #[fail(display = "Logging Error: '{}'", _0)]
 pub struct LoggingError(std::io::Error);
 
-async fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn print(args: Vec<Value>) -> Result<Value, Error> {
     let args = min_args!(1, args)?;
 
     for arg in args {
@@ -37,11 +37,9 @@ async fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Unit)
 }
 
-async fn println(args: Option<Vec<Value>>) -> Result<Value, Error> {
-    if let Some(args) = args {
-        for arg in args {
-            print!("{}", arg);
-        }
+async fn println(args: Vec<Value>) -> Result<Value, Error> {
+    for arg in args {
+        print!("{}", arg);
     }
 
     print!("\n");

--- a/smpli/src/builtins/log.rs
+++ b/smpli/src/builtins/log.rs
@@ -15,8 +15,8 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(LOG_PRINT,   boxed_print)
-        .add_builtin(LOG_PRINTLN, boxed_println);
+        .add_builtin(LOG_PRINT,   super::erase(print))
+        .add_builtin(LOG_PRINTLN, super::erase(println));
 
     module
 }
@@ -24,9 +24,6 @@ pub fn vm_module() -> VmModule {
 #[derive(Fail, Debug)]
 #[fail(display = "Logging Error: '{}'", _0)]
 pub struct LoggingError(std::io::Error);
-
-async_box!(print);
-async_box!(println);
 
 async fn print(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = min_args!(1, args)?;

--- a/smpli/src/builtins/math.rs
+++ b/smpli/src/builtins/math.rs
@@ -33,27 +33,43 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(MATH_SIN, sin)
-        .add_builtin(MATH_COS, cos)
-        .add_builtin(MATH_TAN, tan)
-        .add_builtin(MATH_ASIN, asin)
-        .add_builtin(MATH_ACOS, acos)
-        .add_builtin(MATH_ATAN, atan)
-        .add_builtin(MATH_ATAN2, atan2)
-        .add_builtin(MATH_TO_RADIANS, to_radians)
-        .add_builtin(MATH_TO_DEGREES, to_degrees)
-        .add_builtin(MATH_FPOWF, fpowf)
-        .add_builtin(MATH_FPOWI, fpowi)
-        .add_builtin(MATH_IPOW, ipow)
-        .add_builtin(MATH_FLOOR, floor)
-        .add_builtin(MATH_CEIL, ceil)
-        .add_builtin(MATH_ROUND, round);
+        .add_builtin(MATH_SIN,          boxed_sin)
+        .add_builtin(MATH_COS,          boxed_cos)
+        .add_builtin(MATH_TAN,          boxed_tan)
+        .add_builtin(MATH_ASIN,         boxed_asin)
+        .add_builtin(MATH_ACOS,         boxed_acos)
+        .add_builtin(MATH_ATAN,         boxed_atan)
+        .add_builtin(MATH_ATAN2,        boxed_atan2)
+        .add_builtin(MATH_TO_RADIANS,   boxed_to_radians)
+        .add_builtin(MATH_TO_DEGREES,   boxed_to_degrees)
+        .add_builtin(MATH_FPOWF,        boxed_fpowf)
+        .add_builtin(MATH_FPOWI,        boxed_fpowi)
+        .add_builtin(MATH_IPOW,         boxed_ipow)
+        .add_builtin(MATH_FLOOR,        boxed_floor)
+        .add_builtin(MATH_CEIL,         boxed_ceil)
+        .add_builtin(MATH_ROUND,        boxed_round);
 
     module
 }
 
+async_box!(sin);
+async_box!(cos);
+async_box!(tan);
+async_box!(asin);
+async_box!(acos);
+async_box!(atan);
+async_box!(atan2);
+async_box!(to_radians);
+async_box!(to_degrees);
+async_box!(fpowf);
+async_box!(fpowi);
+async_box!(ipow);
+async_box!(floor);
+async_box!(ceil);
+async_box!(round);
+
 /// In radians
-fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -64,7 +80,7 @@ fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn cos(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn cos(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -75,7 +91,7 @@ fn cos(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn tan(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn tan(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -86,7 +102,7 @@ fn tan(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn asin(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn asin(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -97,7 +113,7 @@ fn asin(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn acos(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn acos(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -108,7 +124,7 @@ fn acos(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn atan(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn atan(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -119,7 +135,7 @@ fn atan(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-fn atan2(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn atan2(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let v = args.get(0).unwrap().clone();
     let a = args.get(1).unwrap().clone();
@@ -130,7 +146,7 @@ fn atan2(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn to_radians(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_radians(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -140,7 +156,7 @@ fn to_radians(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn to_degrees(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_degrees(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -150,7 +166,7 @@ fn to_degrees(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn fpowf(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn fpowf(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -161,7 +177,7 @@ fn fpowf(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn fpowi(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn fpowi(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -183,7 +199,7 @@ fn fpowi(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn ipow(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn ipow(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -206,7 +222,7 @@ fn ipow(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn floor(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn floor(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -216,7 +232,7 @@ fn floor(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn ceil(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn ceil(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -226,7 +242,7 @@ fn ceil(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-fn round(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn round(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 

--- a/smpli/src/builtins/math.rs
+++ b/smpli/src/builtins/math.rs
@@ -33,40 +33,24 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(MATH_SIN,          boxed_sin)
-        .add_builtin(MATH_COS,          boxed_cos)
-        .add_builtin(MATH_TAN,          boxed_tan)
-        .add_builtin(MATH_ASIN,         boxed_asin)
-        .add_builtin(MATH_ACOS,         boxed_acos)
-        .add_builtin(MATH_ATAN,         boxed_atan)
-        .add_builtin(MATH_ATAN2,        boxed_atan2)
-        .add_builtin(MATH_TO_RADIANS,   boxed_to_radians)
-        .add_builtin(MATH_TO_DEGREES,   boxed_to_degrees)
-        .add_builtin(MATH_FPOWF,        boxed_fpowf)
-        .add_builtin(MATH_FPOWI,        boxed_fpowi)
-        .add_builtin(MATH_IPOW,         boxed_ipow)
-        .add_builtin(MATH_FLOOR,        boxed_floor)
-        .add_builtin(MATH_CEIL,         boxed_ceil)
-        .add_builtin(MATH_ROUND,        boxed_round);
+        .add_builtin(MATH_SIN,          super::erase(sin))
+        .add_builtin(MATH_COS,          super::erase(cos))
+        .add_builtin(MATH_TAN,          super::erase(tan))
+        .add_builtin(MATH_ASIN,         super::erase(asin))
+        .add_builtin(MATH_ACOS,         super::erase(acos))
+        .add_builtin(MATH_ATAN,         super::erase(atan))
+        .add_builtin(MATH_ATAN2,        super::erase(atan2))
+        .add_builtin(MATH_TO_RADIANS,   super::erase(to_radians))
+        .add_builtin(MATH_TO_DEGREES,   super::erase(to_degrees))
+        .add_builtin(MATH_FPOWF,        super::erase(fpowf))
+        .add_builtin(MATH_FPOWI,        super::erase(fpowi))
+        .add_builtin(MATH_IPOW,         super::erase(ipow))
+        .add_builtin(MATH_FLOOR,        super::erase(floor))
+        .add_builtin(MATH_CEIL,         super::erase(ceil))
+        .add_builtin(MATH_ROUND,        super::erase(round));
 
     module
 }
-
-async_box!(sin);
-async_box!(cos);
-async_box!(tan);
-async_box!(asin);
-async_box!(acos);
-async_box!(atan);
-async_box!(atan2);
-async_box!(to_radians);
-async_box!(to_degrees);
-async_box!(fpowf);
-async_box!(fpowi);
-async_box!(ipow);
-async_box!(floor);
-async_box!(ceil);
-async_box!(round);
 
 /// In radians
 async fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {

--- a/smpli/src/builtins/math.rs
+++ b/smpli/src/builtins/math.rs
@@ -53,7 +53,7 @@ pub fn vm_module() -> VmModule {
 }
 
 /// In radians
-async fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn sin(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -64,7 +64,7 @@ async fn sin(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn cos(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn cos(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -75,7 +75,7 @@ async fn cos(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn tan(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn tan(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -86,7 +86,7 @@ async fn tan(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn asin(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn asin(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -97,7 +97,7 @@ async fn asin(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn acos(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn acos(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -108,7 +108,7 @@ async fn acos(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn atan(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn atan(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -119,7 +119,7 @@ async fn atan(args: Option<Vec<Value>>) -> Result<Value, Error> {
 }
 
 /// In radians
-async fn atan2(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn atan2(args: Vec<Value>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let v = args.get(0).unwrap().clone();
     let a = args.get(1).unwrap().clone();
@@ -130,7 +130,7 @@ async fn atan2(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn to_radians(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_radians(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -140,7 +140,7 @@ async fn to_radians(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn to_degrees(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_degrees(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -150,7 +150,7 @@ async fn to_degrees(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn fpowf(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn fpowf(args: Vec<Value>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -161,7 +161,7 @@ async fn fpowf(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn fpowi(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn fpowi(args: Vec<Value>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -183,7 +183,7 @@ async fn fpowi(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn ipow(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn ipow(args: Vec<Value>) -> Result<Value, Error> {
     let args = exact_args!(2, args)?;
     let b = args.get(0).unwrap().clone();
     let p = args.get(1).unwrap().clone();
@@ -206,7 +206,7 @@ async fn ipow(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn floor(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn floor(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -216,7 +216,7 @@ async fn floor(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn ceil(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn ceil(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 
@@ -226,7 +226,7 @@ async fn ceil(args: Option<Vec<Value>>) -> Result<Value, Error> {
     }
 }
 
-async fn round(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn round(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let v = args.remove(0);
 

--- a/smpli/src/builtins/mod.rs
+++ b/smpli/src/builtins/mod.rs
@@ -3,7 +3,7 @@ macro_rules! async_box {
     ($name: ident) => {
         paste::item! {
             fn [<boxed_ $name>](args: crate::vm_i::ArgType) -> crate::vm_i::NativeReturn {
-                Box::new($name(args))
+                Box::pin($name(args))
             }
         }
     }

--- a/smpli/src/builtins/mod.rs
+++ b/smpli/src/builtins/mod.rs
@@ -1,15 +1,3 @@
-#[macro_export]
-macro_rules! async_box {
-    ($name: ident) => {
-        paste::item! {
-            fn [<boxed_ $name>](args: crate::vm_i::ArgType) -> crate::vm_i::NativeReturn {
-                Box::pin($name(args))
-            }
-        }
-    }
-}
-
-
 pub mod convert;
 pub mod err;
 pub mod log;
@@ -17,3 +5,21 @@ pub mod math;
 pub mod str;
 pub mod vec;
 pub mod option;
+
+
+use crate::vm_i::{ BuiltinResult, BuiltinFn, ArgType};
+
+/// Provided by u/dtolnay
+pub fn erase<F, Fut>(_f: F) -> BuiltinFn
+    where
+        F: Fn(ArgType)-> Fut + Copy,
+        Fut: std::future::Future<Output=BuiltinResult> + 'static,
+
+{
+    assert_eq!(std::mem::size_of::<F>(), 0);
+    |args| Box::pin(unsafe {
+        // F is zero-zied
+        // Type is enough to identify which function to call
+        std::mem::zeroed::<F>()
+    }(args))
+}

--- a/smpli/src/builtins/mod.rs
+++ b/smpli/src/builtins/mod.rs
@@ -1,3 +1,15 @@
+#[macro_export]
+macro_rules! async_box {
+    ($name: ident) => {
+        paste::item! {
+            fn [<boxed_ $name>](args: crate::vm_i::ArgType) -> crate::vm_i::NativeReturn {
+                Box::new($name(args))
+            }
+        }
+    }
+}
+
+
 pub mod convert;
 pub mod err;
 pub mod log;

--- a/smpli/src/builtins/option.rs
+++ b/smpli/src/builtins/option.rs
@@ -43,12 +43,12 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(OPTION_SOME,    boxed_builtin_make_some)
-        .add_builtin(OPTION_IS_SOME, boxed_builtin_is_some)
-        .add_builtin(OPTION_UNWRAP,  boxed_builtin_unwrap)
-        .add_builtin(OPTION_EXPECT,  boxed_builtin_expect)
-        .add_builtin(OPTION_NONE,    boxed_builtin_make_none)
-        .add_builtin(OPTION_IS_NONE, boxed_builtin_is_none)
+        .add_builtin(OPTION_SOME,    super::erase(builtin_make_some))
+        .add_builtin(OPTION_IS_SOME, super::erase(builtin_is_some))
+        .add_builtin(OPTION_UNWRAP,  super::erase(builtin_unwrap))
+        .add_builtin(OPTION_EXPECT,  super::erase(builtin_expect))
+        .add_builtin(OPTION_NONE,    super::erase(builtin_make_none))
+        .add_builtin(OPTION_IS_NONE, super::erase(builtin_is_none))
     ;
 
     module
@@ -146,13 +146,6 @@ pub fn expect(value: Value, message: String) -> Result<Value, Error> {
         v => Err(OptionError::NonOption)?,
     }
 }
-
-async_box!(builtin_make_some);
-async_box!(builtin_is_some);
-async_box!(builtin_unwrap);
-async_box!(builtin_expect);
-async_box!(builtin_make_none);
-async_box!(builtin_is_none);
 
 async fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;

--- a/smpli/src/builtins/option.rs
+++ b/smpli/src/builtins/option.rs
@@ -147,7 +147,7 @@ pub fn expect(value: Value, message: String) -> Result<Value, Error> {
     }
 }
 
-async fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_make_some(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -155,7 +155,7 @@ async fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(make_some(data))
 }
 
-async fn builtin_is_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_is_some(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -163,7 +163,7 @@ async fn builtin_is_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Bool(is_some(data)))
 }
 
-async fn builtin_unwrap(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_unwrap(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -171,7 +171,7 @@ async fn builtin_unwrap(args: Option<Vec<Value>>) -> Result<Value, Error> {
     unwrap(data)
 }
 
-async fn builtin_expect(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_expect(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let message = args.pop().unwrap();
@@ -182,13 +182,13 @@ async fn builtin_expect(args: Option<Vec<Value>>) -> Result<Value, Error> {
     expect(data, message)
 }
 
-async fn builtin_make_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_make_none(args: Vec<Value>) -> Result<Value, Error> {
     no_args!(args)?;
 
     Ok(make_none())
 }
 
-async fn builtin_is_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_is_none(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();

--- a/smpli/src/builtins/option.rs
+++ b/smpli/src/builtins/option.rs
@@ -43,12 +43,12 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(OPTION_SOME, builtin_make_some)
-        .add_builtin(OPTION_IS_SOME, builtin_is_some)
-        .add_builtin(OPTION_UNWRAP, builtin_unwrap)
-        .add_builtin(OPTION_EXPECT, builtin_expect)
-        .add_builtin(OPTION_NONE, builtin_make_none)
-        .add_builtin(OPTION_IS_NONE, builtin_is_none)
+        .add_builtin(OPTION_SOME,    boxed_builtin_make_some)
+        .add_builtin(OPTION_IS_SOME, boxed_builtin_is_some)
+        .add_builtin(OPTION_UNWRAP,  boxed_builtin_unwrap)
+        .add_builtin(OPTION_EXPECT,  boxed_builtin_expect)
+        .add_builtin(OPTION_NONE,    boxed_builtin_make_none)
+        .add_builtin(OPTION_IS_NONE, boxed_builtin_is_none)
     ;
 
     module
@@ -147,7 +147,14 @@ pub fn expect(value: Value, message: String) -> Result<Value, Error> {
     }
 }
 
-fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async_box!(builtin_make_some);
+async_box!(builtin_is_some);
+async_box!(builtin_unwrap);
+async_box!(builtin_expect);
+async_box!(builtin_make_none);
+async_box!(builtin_is_none);
+
+async fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -155,7 +162,7 @@ fn builtin_make_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(make_some(data))
 }
 
-fn builtin_is_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_is_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -163,7 +170,7 @@ fn builtin_is_some(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Bool(is_some(data)))
 }
 
-fn builtin_unwrap(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_unwrap(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();
@@ -171,7 +178,7 @@ fn builtin_unwrap(args: Option<Vec<Value>>) -> Result<Value, Error> {
     unwrap(data)
 }
 
-fn builtin_expect(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_expect(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let message = args.pop().unwrap();
@@ -182,13 +189,13 @@ fn builtin_expect(args: Option<Vec<Value>>) -> Result<Value, Error> {
     expect(data, message)
 }
 
-fn builtin_make_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_make_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
     no_args!(args)?;
 
     Ok(make_none())
 }
 
-fn builtin_is_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn builtin_is_none(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let data = args.pop().unwrap();

--- a/smpli/src/builtins/option.rs
+++ b/smpli/src/builtins/option.rs
@@ -234,7 +234,7 @@ fn test() -> option::Option(type String) {
     return o1;
 }
 ";
-        let result = option_test!(mod1, "mod1", "test", None);
+        let result = option_test!(mod1, "mod1", "test", vec![]);
 
         let result = irmatch!(result; Value::Struct(inner) => inner);
 
@@ -257,7 +257,7 @@ fn test() -> option::Option(type String) {
     return o1;
 }
 ";
-        let result = option_test!(mod1, "mod1", "test", None);
+        let result = option_test!(mod1, "mod1", "test", vec![]);
 
         let result = irmatch!(result; Value::Struct(inner) => inner);
 
@@ -292,10 +292,10 @@ fn is_some_false() -> bool {
     let o1: option::Option(type String) = option::none(type String)();
     return option::is_some(type String)(o1);
 }";
-        let is_none_true = option_test!(mod1, "mod1", "is_none_true", None);
-        let is_some_true = option_test!(mod1, "mod1", "is_some_true", None);
-        let is_none_false = option_test!(mod1, "mod1", "is_none_false", None);
-        let is_some_false = option_test!(mod1, "mod1", "is_some_false", None);
+        let is_none_true = option_test!(mod1, "mod1", "is_none_true", vec![]);
+        let is_some_true = option_test!(mod1, "mod1", "is_some_true", vec![]);
+        let is_none_false = option_test!(mod1, "mod1", "is_none_false", vec![]);
+        let is_some_false = option_test!(mod1, "mod1", "is_some_false", vec![]);
 
         assert_eq!(is_none_true, Value::Bool(true));
         assert_eq!(is_some_true, Value::Bool(true));
@@ -320,8 +320,8 @@ fn expect() -> String {
     return option::expect(type String)(o1, \"ERROR\"); 
 }";
 
-        let unwrap = option_test!(mod1, "mod1", "unwrap", None);
-        let expect = option_test!(mod1, "mod1", "expect", None);
+        let unwrap = option_test!(mod1, "mod1", "unwrap", vec![]);
+        let expect = option_test!(mod1, "mod1", "expect", vec![]);
 
         assert_eq!(unwrap, Value::String("Hello world".to_string()));
         assert_eq!(expect, Value::String("Hello world".to_string()));

--- a/smpli/src/builtins/str.rs
+++ b/smpli/src/builtins/str.rs
@@ -18,16 +18,22 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(STRING_LEN, len)
-        .add_builtin(STRING_TO_STRING, to_string)
-        .add_builtin(STRING_APPEND, append)
-        .add_builtin(STRING_TO_LOWER, to_lower)
-        .add_builtin(STRING_TO_UPPER, to_upper);
+        .add_builtin(STRING_LEN,        boxed_len)
+        .add_builtin(STRING_TO_STRING,  boxed_to_string)
+        .add_builtin(STRING_APPEND,     boxed_append)
+        .add_builtin(STRING_TO_LOWER,   boxed_to_lower)
+        .add_builtin(STRING_TO_UPPER,   boxed_to_upper);
 
     module
 }
 
-fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async_box!(len);
+async_box!(to_string);
+async_box!(append);
+async_box!(to_lower);
+async_box!(to_upper);
+
+async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();
@@ -36,7 +42,7 @@ fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Int(string.len() as i64))
 }
 
-fn to_string(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_string(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = min_args!(1, args)?;
 
     let mut s = String::new();
@@ -48,7 +54,7 @@ fn to_string(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(s))
 }
 
-fn append(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn append(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = min_args!(1, args)?;
 
     let to_append = args.pop().unwrap();
@@ -62,7 +68,7 @@ fn append(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(base))
 }
 
-fn to_lower(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_lower(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();
@@ -71,7 +77,7 @@ fn to_lower(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(string.to_lowercase()))
 }
 
-fn to_upper(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_upper(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();

--- a/smpli/src/builtins/str.rs
+++ b/smpli/src/builtins/str.rs
@@ -27,7 +27,7 @@ pub fn vm_module() -> VmModule {
     module
 }
 
-async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn len(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();
@@ -36,7 +36,7 @@ async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Int(string.len() as i64))
 }
 
-async fn to_string(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_string(args: Vec<Value>) -> Result<Value, Error> {
     let args = min_args!(1, args)?;
 
     let mut s = String::new();
@@ -48,7 +48,7 @@ async fn to_string(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(s))
 }
 
-async fn append(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn append(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = min_args!(1, args)?;
 
     let to_append = args.pop().unwrap();
@@ -62,7 +62,7 @@ async fn append(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(base))
 }
 
-async fn to_lower(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_lower(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();
@@ -71,7 +71,7 @@ async fn to_lower(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::String(string.to_lowercase()))
 }
 
-async fn to_upper(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn to_upper(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
 
     let string = args.pop().unwrap();

--- a/smpli/src/builtins/str.rs
+++ b/smpli/src/builtins/str.rs
@@ -18,20 +18,14 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(STRING_LEN,        boxed_len)
-        .add_builtin(STRING_TO_STRING,  boxed_to_string)
-        .add_builtin(STRING_APPEND,     boxed_append)
-        .add_builtin(STRING_TO_LOWER,   boxed_to_lower)
-        .add_builtin(STRING_TO_UPPER,   boxed_to_upper);
+        .add_builtin(STRING_LEN,        super::erase(len))
+        .add_builtin(STRING_TO_STRING,  super::erase(to_string))
+        .add_builtin(STRING_APPEND,     super::erase(append))
+        .add_builtin(STRING_TO_LOWER,   super::erase(to_lower))
+        .add_builtin(STRING_TO_UPPER,   super::erase(to_upper));
 
     module
 }
-
-async_box!(len);
-async_box!(to_string);
-async_box!(append);
-async_box!(to_lower);
-async_box!(to_upper);
 
 async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;

--- a/smpli/src/builtins/str.rs
+++ b/smpli/src/builtins/str.rs
@@ -98,7 +98,7 @@ mod tests {
         let fn_handle = vm.query_module(MOD_STRING, STRING_LEN).unwrap().unwrap();
 
         let result = vm
-            .spawn_executor(fn_handle, Some(vec![Value::String("".to_string())]), SpawnOptions {
+            .spawn_executor(fn_handle, vec![Value::String("".to_string())], SpawnOptions {
                 type_check: false
             })
             .unwrap()
@@ -107,7 +107,7 @@ mod tests {
         assert_eq!(Value::Int(0), result);
 
         let result = vm
-            .spawn_executor(fn_handle, Some(vec![Value::String("1".to_string())]), SpawnOptions {
+            .spawn_executor(fn_handle, vec![Value::String("1".to_string())], SpawnOptions {
                 type_check: false    
             })
             .unwrap()
@@ -118,7 +118,7 @@ mod tests {
         let result = vm
             .spawn_executor(
                 fn_handle,
-                Some(vec![Value::String("123456789".to_string())]),
+                vec![Value::String("123456789".to_string())],
                 SpawnOptions {
                     type_check: false
                 }
@@ -141,11 +141,11 @@ mod tests {
         let result = vm
             .spawn_executor(
                 fn_handle,
-                Some(vec![
+                vec![
                     Value::String("I am ".to_string()),
                     Value::Int(1337),
                     Value::String("!".to_string()),
-                ]),
+                ],
                 SpawnOptions {
                     type_check: false
                 }
@@ -165,10 +165,10 @@ mod tests {
         let result = vm
             .spawn_executor(
                 fn_handle,
-                Some(vec![
+                vec![
                     Value::String("I'll ".to_string()),
                     Value::String("be back.".to_string()),
-                ]),
+                ],
                 SpawnOptions {
                     type_check: false
                 }
@@ -191,7 +191,7 @@ mod tests {
         let result = vm
             .spawn_executor(
                 fn_handle,
-                Some(vec![Value::String("LOUD NOISES".to_string())]),
+                vec![Value::String("LOUD NOISES".to_string())],
                 SpawnOptions {
                     type_check: false,
                 }
@@ -214,7 +214,7 @@ mod tests {
         let result = vm
             .spawn_executor(
                 fn_handle,
-                Some(vec![Value::String("loud noises".to_string())]),
+                vec![Value::String("loud noises".to_string())],
                 SpawnOptions {
                     type_check: false,
                 }
@@ -244,7 +244,7 @@ return str::to_string(\"Cannot\", \" touch\", \" this!?\");
 
     let fn_handle = vm.query_module("mod1", "test").unwrap().unwrap();
 
-    let result = vm.spawn_executor(fn_handle, None, SpawnOptions {
+    let result = vm.spawn_executor(fn_handle, vec![], SpawnOptions {
         type_check: false    
     })
         .unwrap()

--- a/smpli/src/builtins/vec.rs
+++ b/smpli/src/builtins/vec.rs
@@ -306,7 +306,7 @@ fn vec_new() {
     let v: vec::Vec(type int)= vec::new(type int)();
 }
 ";
-    let result = vec_test!(mod1, "mod1", "vec_new", None);
+    let result = vec_test!(mod1, "mod1", "vec_new", vec![]);
 
     assert_eq!(Value::Unit, result);
 }
@@ -327,7 +327,7 @@ return vec::len(type int)(v);
 }
 ";
 
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Int(2), result);
 }
@@ -352,7 +352,7 @@ return a * b;
 ";
 
 
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Int(123 * 456), result);
 }
@@ -376,7 +376,7 @@ return vec::get_value(type int)(v, 1);
 }
 ";
     
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Int(789), result);
 }
@@ -401,7 +401,7 @@ return a;
 }
 ";
     
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Int(1337), result);
 }
@@ -440,11 +440,11 @@ return vec::contains(type int)(v, 20);
 }
 ";
     
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Bool(true), result);
 
-    let result = vec_test!(mod1, "mod1", "test2", None);
+    let result = vec_test!(mod1, "mod1", "test2", vec![]);
 
     assert_eq!(Value::Bool(false), result);
 }
@@ -467,7 +467,7 @@ return vec::len(type int)(cleared);
 }
 ";
 
-    let result = vec_test!(mod1, "mod1", "test", None);
+    let result = vec_test!(mod1, "mod1", "test", vec![]);
 
     assert_eq!(Value::Int(0), result);
 }

--- a/smpli/src/builtins/vec.rs
+++ b/smpli/src/builtins/vec.rs
@@ -46,7 +46,7 @@ pub enum VecError {
     IndexOutOfRange(i64, usize),
 }
 
-async fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn new(args: Vec<Value>) -> Result<Value, Error> {
     no_args!(args)?;
 
     let mut vec = Struct::new();
@@ -56,7 +56,7 @@ async fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec))
 }
 
-async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn len(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let vec_struct = args.pop().unwrap();
     let vec_struct = irmatch!(vec_struct; Value::Struct(s) => s);
@@ -66,7 +66,7 @@ async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(length)
 }
 
-async fn contains(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn contains(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let to_search = args.pop().unwrap();
@@ -89,7 +89,7 @@ async fn contains(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Bool(false))
 }
 
-async fn insert(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn insert(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(3, args)?;
 
     let to_insert = args.pop().unwrap();
@@ -117,7 +117,7 @@ async fn insert(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-async fn push(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn push(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let to_insert = args.pop().unwrap();
@@ -143,7 +143,7 @@ async fn push(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-async fn get_value(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn get_value(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let index = args.pop().unwrap();
@@ -171,7 +171,7 @@ async fn get_value(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(item)
 }
 
-async fn get(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn get(args: Vec<Value>) -> Result<Value, Error> {
     use super::option;
 
     let mut args = exact_args!(2, args)?;
@@ -201,7 +201,7 @@ async fn get(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(option::make_some(item))
 }
 
-async fn remove(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn remove(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let index = args.pop().unwrap();
@@ -238,7 +238,7 @@ async fn remove(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-async fn clear(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn clear(args: Vec<Value>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let vec_struct = args.pop().unwrap();
     let vec_struct = irmatch!(vec_struct; Value::Struct(s) => s);

--- a/smpli/src/builtins/vec.rs
+++ b/smpli/src/builtins/vec.rs
@@ -27,15 +27,15 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(VEC_NEW, new)
-        .add_builtin(VEC_LEN, len)
-        .add_builtin(VEC_CONTAINS, contains)
-        .add_builtin(VEC_PUSH, push)
-        .add_builtin(VEC_INSERT, insert)
-        .add_builtin(VEC_GET_VALUE, get_value)
-        .add_builtin(VEC_GET, get)
-        .add_builtin(VEC_REMOVE, remove)
-        .add_builtin(VEC_CLEAR, clear);
+        .add_builtin(VEC_NEW,       boxed_new)
+        .add_builtin(VEC_LEN,       boxed_len)
+        .add_builtin(VEC_CONTAINS,  boxed_contains)
+        .add_builtin(VEC_PUSH,      boxed_push)
+        .add_builtin(VEC_INSERT,    boxed_insert)
+        .add_builtin(VEC_GET_VALUE, boxed_get_value)
+        .add_builtin(VEC_GET,       boxed_get)
+        .add_builtin(VEC_REMOVE,    boxed_remove)
+        .add_builtin(VEC_CLEAR,     boxed_clear);
 
     module
 }
@@ -46,7 +46,17 @@ pub enum VecError {
     IndexOutOfRange(i64, usize),
 }
 
-fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async_box!(new);
+async_box!(len);
+async_box!(contains);
+async_box!(push);
+async_box!(insert);
+async_box!(get_value);
+async_box!(get);
+async_box!(remove);
+async_box!(clear);
+
+async fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
     no_args!(args)?;
 
     let mut vec = Struct::new();
@@ -56,7 +66,7 @@ fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec))
 }
 
-fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let vec_struct = args.pop().unwrap();
     let vec_struct = irmatch!(vec_struct; Value::Struct(s) => s);
@@ -66,7 +76,7 @@ fn len(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(length)
 }
 
-fn contains(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn contains(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let to_search = args.pop().unwrap();
@@ -89,7 +99,7 @@ fn contains(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Bool(false))
 }
 
-fn insert(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn insert(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(3, args)?;
 
     let to_insert = args.pop().unwrap();
@@ -117,7 +127,7 @@ fn insert(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-fn push(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn push(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let to_insert = args.pop().unwrap();
@@ -143,7 +153,7 @@ fn push(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-fn get_value(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn get_value(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let index = args.pop().unwrap();
@@ -171,7 +181,7 @@ fn get_value(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(item)
 }
 
-fn get(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn get(args: Option<Vec<Value>>) -> Result<Value, Error> {
     use super::option;
 
     let mut args = exact_args!(2, args)?;
@@ -201,7 +211,7 @@ fn get(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(option::make_some(item))
 }
 
-fn remove(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn remove(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(2, args)?;
 
     let index = args.pop().unwrap();
@@ -238,7 +248,7 @@ fn remove(args: Option<Vec<Value>>) -> Result<Value, Error> {
     Ok(Value::Struct(vec_struct))
 }
 
-fn clear(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn clear(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let mut args = exact_args!(1, args)?;
     let vec_struct = args.pop().unwrap();
     let vec_struct = irmatch!(vec_struct; Value::Struct(s) => s);

--- a/smpli/src/builtins/vec.rs
+++ b/smpli/src/builtins/vec.rs
@@ -27,15 +27,15 @@ pub fn vm_module() -> VmModule {
     let parsed = parse_module(input).unwrap();
 
     let module = VmModule::new(parsed)
-        .add_builtin(VEC_NEW,       boxed_new)
-        .add_builtin(VEC_LEN,       boxed_len)
-        .add_builtin(VEC_CONTAINS,  boxed_contains)
-        .add_builtin(VEC_PUSH,      boxed_push)
-        .add_builtin(VEC_INSERT,    boxed_insert)
-        .add_builtin(VEC_GET_VALUE, boxed_get_value)
-        .add_builtin(VEC_GET,       boxed_get)
-        .add_builtin(VEC_REMOVE,    boxed_remove)
-        .add_builtin(VEC_CLEAR,     boxed_clear);
+        .add_builtin(VEC_NEW,       super::erase(new))
+        .add_builtin(VEC_LEN,       super::erase(len))
+        .add_builtin(VEC_CONTAINS,  super::erase(contains))
+        .add_builtin(VEC_PUSH,      super::erase(push))
+        .add_builtin(VEC_INSERT,    super::erase(insert))
+        .add_builtin(VEC_GET_VALUE, super::erase(get_value))
+        .add_builtin(VEC_GET,       super::erase(get))
+        .add_builtin(VEC_REMOVE,    super::erase(remove))
+        .add_builtin(VEC_CLEAR,     super::erase(clear));
 
     module
 }
@@ -45,16 +45,6 @@ pub enum VecError {
     #[fail(display = "Index '{}' out of range ('{}')", _0, _1)]
     IndexOutOfRange(i64, usize),
 }
-
-async_box!(new);
-async_box!(len);
-async_box!(contains);
-async_box!(push);
-async_box!(insert);
-async_box!(get_value);
-async_box!(get);
-async_box!(remove);
-async_box!(clear);
 
 async fn new(args: Option<Vec<Value>>) -> Result<Value, Error> {
     no_args!(args)?;

--- a/smpli/src/err.rs
+++ b/smpli/src/err.rs
@@ -120,13 +120,13 @@ pub enum ExpectedArgCount {
 macro_rules! no_args {
     ($args: expr) => {{
         use crate::err::*;
-        match $args {
-            Some(args) => Err(InternalError::InvalidArgCount(
-                args.len(),
+        if $args.len() != 0 {
+            Err(InternalError::InvalidArgCount(
+                $args.len(),
                 ExpectedArgCount::Exact(0),
-            )),
-
-            None => Ok(()),
+            ))
+        } else {
+            Ok(())
         }
     }};
 }
@@ -135,27 +135,13 @@ macro_rules! no_args {
 macro_rules! exact_args {
     ($exact: expr, $args: expr) => {{
         use crate::err::*;
-        match $args {
-            Some(args) => {
-                if args.len() != $exact {
-                    Err(InternalError::InvalidArgCount(
-                        args.len(),
-                        ExpectedArgCount::Exact($exact),
-                    ))
-                } else {
-                    Ok(args)
-                }
-            }
-
-            None => {
-                // Assume $exact != 0 to make types nicer
-                // Use no_args!() instead
-                assert!($exact != 0);
-                Err(InternalError::InvalidArgCount(
-                    0,
-                    ExpectedArgCount::Exact($exact),
-                ))
-            }
+        if $args.len() != $exact {
+            Err(InternalError::InvalidArgCount(
+                $args.len(),
+                ExpectedArgCount::Exact($exact),
+            ))
+        } else {
+            Ok($args)
         }
     }};
 }
@@ -165,26 +151,13 @@ macro_rules! exact_args {
 macro_rules! min_args {
     ($min: expr, $args: expr) => {{
         use crate::err::*;
-        match $args {
-            Some(args) => {
-                if args.len() < $min {
-                    Err(InternalError::InvalidArgCount(
-                        args.len(),
-                        ExpectedArgCount::Min($min),
-                    ))
-                } else {
-                    Ok(args)
-                }
-            }
-
-            None => {
-                // min = 0 is the same as not checking the arguments
-                assert!($min != 0);
-                Err(InternalError::InvalidArgCount(
-                    0,
-                    ExpectedArgCount::Min($min),
-                ))
-            }
+        if $args.len() < $min {
+            Err(InternalError::InvalidArgCount(
+                $args.len(),
+                ExpectedArgCount::Min($min),
+            ))
+        } else {
+            Ok($args)
         }
     }};
 }
@@ -194,19 +167,13 @@ macro_rules! min_args {
 macro_rules! max_args {
     ($max: expr, $args: expr) => {{
         use crate::err::*;
-        match $args {
-            Some(args) => {
-                if args.len() > $max {
-                    Err(InternalError::InvalidArgCount(
-                        args.len(),
-                        ExpectedArgCount::Max($max),
-                    ))
-                } else {
-                    Ok(Some(args))
-                }
-            }
-
-            None => Ok(None),
+        if $args.len() > $max {
+            Err(InternalError::InvalidArgCount(
+                $args.len(),
+                ExpectedArgCount::Max($max),
+            ))
+        } else {
+            Ok($args)
         }
     }};
 }
@@ -217,29 +184,13 @@ macro_rules! arg_range_inclusive {
     // Assume min_inclusive is greater than 1
     ($min_inclusive: expr, $max_inclusive: expr, $args: expr) => {{
         use crate::err::*;
-        match $args {
-            Some(args) => {
-                if $min_inclusive <= args.len() && $max_inclusive >= args.len() {
-                    Ok(args)
-                } else {
-                    Err(InternalError::InvalidArgCount(
-                        args.len(),
-                        ExpectedArgCount::Range($min_inclusive, $max_inclusive),
-                    ))
-                }
-            }
-
-            None => {
-                // Assume min_inclusive is greater than 0
-                // If min_inclusive == 0, use max_args instead
-                if $min_inclusive == 0 {
-                    panic!("Minimum inclusive is 0. Use max_args!() instead");
-                }
-                Err(InternalError::InvalidArgCount(
-                    0,
-                    ExpectedArgCount::Range($min_inclusive, $max_inclusive),
-                ))
-            }
+        if $min_inclusive <= $args.len() && $max_inclusive >= $args.len() {
+            Ok($args)
+        } else {
+            Err(InternalError::InvalidArgCount(
+                $args.len(),
+                ExpectedArgCount::Range($min_inclusive, $max_inclusive),
+            ))
         }
     }};
 }

--- a/smpli/src/executor.rs
+++ b/smpli/src/executor.rs
@@ -79,11 +79,7 @@ impl Executor {
     }
 
     pub fn execute_sync(mut self) -> Result<Value, Error> {
-        while !self.finished {
-            futures::executor::block_on(self.step())?;
-        }
-
-        Ok(self.return_register.take().unwrap_or(Value::Unit))
+        futures::executor::block_on(self.execute())
     }
 
     pub async fn execute(mut self) -> Result<Value, Error> {

--- a/smpli/src/executor.rs
+++ b/smpli/src/executor.rs
@@ -80,7 +80,7 @@ impl Executor {
 
     pub fn execute_sync(mut self) -> Result<Value, Error> {
         while !self.finished {
-            self.step()?;
+            futures::executor::block_on(self.step())?;
         }
 
         Ok(self.return_register.take().unwrap_or(Value::Unit))

--- a/smpli/src/executor.rs
+++ b/smpli/src/executor.rs
@@ -86,6 +86,14 @@ impl Executor {
         Ok(self.return_register.take().unwrap_or(Value::Unit))
     }
 
+    pub async fn execute(&mut self) -> Result<Value, Error> {
+        while !self.finished {
+            self.step().await?;
+        }
+
+        Ok(self.return_register.take().unwrap_or(Value::Unit))
+    }
+
     fn create_stack_info(metadata: &Metadata,
                       fn_handle: FnHandle, 
                       compiled: CompiledProgram,

--- a/smpli/src/executor.rs
+++ b/smpli/src/executor.rs
@@ -86,7 +86,7 @@ impl Executor {
         Ok(self.return_register.take().unwrap_or(Value::Unit))
     }
 
-    pub async fn execute(&mut self) -> Result<Value, Error> {
+    pub async fn execute(mut self) -> Result<Value, Error> {
         while !self.finished {
             self.step().await?;
         }

--- a/smpli/src/executor.rs
+++ b/smpli/src/executor.rs
@@ -128,7 +128,7 @@ impl Executor {
         }
     }
 
-    fn step(&mut self) -> Result<(), Error> {
+    async fn step(&mut self) -> Result<(), Error> {
         let exec_action = match self.top {
             StackInfo::BuiltinStack(BuiltinStack {
                 ref current_fn,
@@ -137,7 +137,7 @@ impl Executor {
             }) => {
                 // TODO(alex): If StackInfo is going to be used for inspecting,
                 //   need args.clone() instead of args.take()
-                let result = (*current_fn)(args.take())?;
+                let result = (*current_fn)(args.take()).await?;
 
                 ExecuteAction::PopStack(result)
             }

--- a/smpli/src/lib.rs
+++ b/smpli/src/lib.rs
@@ -30,11 +30,13 @@ pub use value:: {
 };
 
 pub use vm_i::{
-    BuiltinFn,
     FnHandle,
     TypeHandle,
+    ArgType,
+    BuiltinResult,
+    NativeReturn,
+    BuiltinFn,
 };
-
 pub use module::VmModule;
 
 pub use std_options::*;

--- a/smpli/src/lib.rs
+++ b/smpli/src/lib.rs
@@ -43,3 +43,5 @@ pub use vm::{ SpawnOptions, AVM };
 pub use executor::Executor;
 
 pub use smpl::{ ParsedModule, UnparsedModule, parse_module };
+
+pub use builtins::erase;

--- a/smpli/src/vm.rs
+++ b/smpli/src/vm.rs
@@ -123,8 +123,8 @@ impl AVM {
         }
     }
 
-    pub fn spawn_executor(&self, fn_handle: FnHandle, 
-                          args: Option<Vec<Value>>, 
+    pub fn spawn_executor(&self, fn_handle: FnHandle,
+                          args: Vec<Value>,
                           spawn_options: SpawnOptions) -> Result<Executor, InternalError> {
 
         if spawn_options.type_check {

--- a/smpli/src/vm_i.rs
+++ b/smpli/src/vm_i.rs
@@ -7,6 +7,7 @@ use smpl::{FnId, TypeId, ModuleId};
 
 use super::value::Value;
 
+// TODO: Add choice between Future/NonFuture builtins?
 pub type ArgType        = Option<Vec<Value>>;
 pub type BuiltinResult  = Result<Value, Error>;
 pub type NativeReturn   = Pin<Box<dyn Future<Output=BuiltinResult>>>;

--- a/smpli/src/vm_i.rs
+++ b/smpli/src/vm_i.rs
@@ -8,7 +8,7 @@ use smpl::{FnId, TypeId, ModuleId};
 use super::value::Value;
 
 // TODO: Add choice between Future/NonFuture builtins?
-pub type ArgType        = Option<Vec<Value>>;
+pub type ArgType        = Vec<Value>;
 pub type BuiltinResult  = Result<Value, Error>;
 pub type NativeReturn   = Pin<Box<dyn Future<Output=BuiltinResult>>>;
 pub type BuiltinFn      = fn(args: ArgType) -> NativeReturn;

--- a/smpli/src/vm_i.rs
+++ b/smpli/src/vm_i.rs
@@ -1,10 +1,15 @@
+use std::future::Future;
+
 use failure::Error;
 
 use smpl::{FnId, TypeId, ModuleId};
 
 use super::value::Value;
 
-pub type BuiltinFn = fn(args: Option<Vec<Value>>) -> Result<Value, Error>;
+pub type ArgType        = Option<Vec<Value>>;
+pub type BuiltinResult  = Result<Value, Error>;
+pub type NativeReturn   = Box<dyn Future<Output=BuiltinResult>>;
+pub type BuiltinFn      = fn(args: ArgType) -> NativeReturn;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModQuery {

--- a/smpli/src/vm_i.rs
+++ b/smpli/src/vm_i.rs
@@ -1,3 +1,4 @@
+use std::pin::Pin;
 use std::future::Future;
 
 use failure::Error;
@@ -8,7 +9,7 @@ use super::value::Value;
 
 pub type ArgType        = Option<Vec<Value>>;
 pub type BuiltinResult  = Result<Value, Error>;
-pub type NativeReturn   = Box<dyn Future<Output=BuiltinResult>>;
+pub type NativeReturn   = Pin<Box<dyn Future<Output=BuiltinResult>>>;
 pub type BuiltinFn      = fn(args: ArgType) -> NativeReturn;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/smpli/src/vm_tests.rs
+++ b/smpli/src/vm_tests.rs
@@ -98,8 +98,7 @@ macro_rules! wrap_input {
     }}
 }
 
-async fn add(args: Option<Vec<Value>>) -> Result<Value, Error> {
-    let args = args.unwrap();
+async fn add(mut args: Vec<Value>) -> Result<Value, Error> {
     let lhs = args.get(0).unwrap();
     let rhs = args.get(1).unwrap();
 
@@ -109,8 +108,7 @@ async fn add(args: Option<Vec<Value>>) -> Result<Value, Error> {
     return Ok(Value::Int(lhs + rhs));
 }
 
-async fn var_arg_sum(args: Option<Vec<Value>>) -> Result<Value, Error> {
-    let args = args.unwrap();
+async fn var_arg_sum(args: Vec<Value>) -> Result<Value, Error> {
 
     let mut sum = 0;
 
@@ -125,14 +123,14 @@ async fn var_arg_sum(args: Option<Vec<Value>>) -> Result<Value, Error> {
 expect_value!(interpreter_basic,
     module :: "mod1",
     eval :: "test",
-    args :: Some(vec![Value::Int(5), Value::Int(7)]),
+    args :: vec![Value::Int(5), Value::Int(7)],
     expect :: Value::Int(12)
 );
 
 expect_value!(interpreter_struct,
     module :: "mod1",
     eval :: "test",
-    args :: Some(vec![Value::Int(5), Value::Int(7)]),
+    args :: vec![Value::Int(5), Value::Int(7)],
     finalizer :: |result|  {
         let result = irmatch!(result; Value::Struct(s) => s.get_field("f").unwrap());
         let result = irmatch!(result; Value::Int(i) => i);
@@ -144,7 +142,7 @@ expect_value!(interpreter_struct,
 expect_value!(interpreter_builtin,
     module :: "mod1",
     eval :: "test",
-    args :: Some(vec![Value::Int(5), Value::Int(7)]), 
+    args :: vec![Value::Int(5), Value::Int(7)], 
     expect :: Value::Int(12),
     builtins :: |vm: VmModule| {
         vm.add_builtin("add", erase(add))
@@ -154,7 +152,7 @@ expect_value!(interpreter_builtin,
 expect_value!(interpreter_builtin_unchecked_params,
     module :: "mod1",
     eval :: "test",
-    args :: Some(vec![Value::Int(5), Value::Int(7)]),
+    args :: vec![Value::Int(5), Value::Int(7)],
     expect :: Value::Int(114),
     builtins :: |vm: VmModule| {
         vm.add_builtin("sum", erase(var_arg_sum))
@@ -195,7 +193,7 @@ return mod1::add(1, 2);
     
     let a_fn_handle = avm.query_module("mod2", "test2").unwrap().unwrap();
 
-    let a_result = avm.spawn_executor(a_fn_handle, None, SpawnOptions {
+    let a_result = avm.spawn_executor(a_fn_handle, vec![], SpawnOptions {
         type_check: false,    
     })
         .unwrap()
@@ -209,77 +207,77 @@ return mod1::add(1, 2);
 expect_value!(interpreter_field_access,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(1337)
 );
 
 expect_value!(interpreter_array,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(1 + 2 + 3 + 4 + 5)
 );
 
 expect_value!(interpreter_fn_value,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(420)
 );
 
 expect_value!(interpreter_optional_local_type_annotation,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(420)
 );
 
 expect_value!(interpreter_recursive_fn_call,
     module :: "mod1",
     eval :: "recurse",
-    args :: Some(vec![Value::Int(2)]),
+    args :: vec![Value::Int(2)],
     expect :: Value::Int(3)
 );
 
 expect_value!(interpreter_mutually_recursive_fn_call,
     module :: "mod1",
     eval :: "recurse_a",
-    args :: Some(vec![Value::Int(1)]),
+    args :: vec![Value::Int(1)],
     expect :: Value::Int(-5)
 );
 
 expect_value!(interpreter_loaded_builtin,
     module :: "mod1",
     eval :: "test_floor",
-    args :: None,
+    args :: vec![],
     expect :: Value::Float(1.0)
 );
 
 expect_value!(interpreter_anonymous_fn_call,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(15)
 );
 
 expect_value!(interpreter_anonymous_fn_arg,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(15)
 );
 
 expect_value!(interpreter_fn_piping,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(5)
 );
 
 expect_value!(interpreter_builtin_bind,
     module :: "mod1",
     eval :: "bar",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(8),
     builtins :: |vm: VmModule| {
         vm.add_builtin("add", erase(add))
@@ -289,35 +287,35 @@ expect_value!(interpreter_builtin_bind,
 expect_value!(interpreter_complex_if,
     module :: "mod1",
     eval :: "foo",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(1000)
 );
 
 expect_value!(interpreter_uni_expr,
     module :: "mod1",
     eval :: "foo",
-    args :: None,
+    args :: vec![],
     expect :: Value::Bool(true)
 );
 
 expect_value!(interpreter_2d_array,
     module :: "mod1",
     eval :: "foo",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(0)
 );
 
 expect_value!(interpreter_structs_complex,
     module :: "mod1",
     eval :: "foo",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(0)
 );
 
 expect_value!(interpreter_while_loop,
     module :: "mod1",
     eval :: "foo",
-    args :: None,
+    args :: vec![],
     expect :: Value::Int(137)
 );
 
@@ -356,7 +354,7 @@ fn test() -> int {
     
     let fn_handle = avm.query_module("mod2", "test").unwrap().unwrap();
 
-    let result = avm.spawn_executor(fn_handle, None, SpawnOptions {
+    let result = avm.spawn_executor(fn_handle, vec![], SpawnOptions {
         type_check: false   
     })
         .expect("Executor spawn error error")
@@ -369,7 +367,7 @@ fn test() -> int {
 expect_value!(interpreter_array_path_assignment,
     module :: "mod1",
     eval :: "test",
-    args :: None,
+    args :: vec![],
     expect :: {
         let array = Array::new_init(vec![
             Value::Int(1),

--- a/smpli/src/vm_tests.rs
+++ b/smpli/src/vm_tests.rs
@@ -98,7 +98,7 @@ macro_rules! wrap_input {
     }}
 }
 
-fn add(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn add(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = args.unwrap();
     let lhs = args.get(0).unwrap();
     let rhs = args.get(1).unwrap();
@@ -109,7 +109,7 @@ fn add(args: Option<Vec<Value>>) -> Result<Value, Error> {
     return Ok(Value::Int(lhs + rhs));
 }
 
-fn var_arg_sum(args: Option<Vec<Value>>) -> Result<Value, Error> {
+async fn var_arg_sum(args: Option<Vec<Value>>) -> Result<Value, Error> {
     let args = args.unwrap();
 
     let mut sum = 0;
@@ -147,7 +147,7 @@ expect_value!(interpreter_builtin,
     args :: Some(vec![Value::Int(5), Value::Int(7)]), 
     expect :: Value::Int(12),
     builtins :: |vm: VmModule| {
-        vm.add_builtin("add", add)
+        vm.add_builtin("add", erase(add))
     }
 );
 
@@ -157,7 +157,7 @@ expect_value!(interpreter_builtin_unchecked_params,
     args :: Some(vec![Value::Int(5), Value::Int(7)]),
     expect :: Value::Int(114),
     builtins :: |vm: VmModule| {
-        vm.add_builtin("sum", var_arg_sum)
+        vm.add_builtin("sum", erase(var_arg_sum))
     }
 );
 
@@ -186,7 +186,7 @@ return mod1::add(1, 2);
     let m2 = parse_module(wrap_input!(mod2)).unwrap();
 
     let m1 = VmModule::new(m1)
-        .add_builtin("add", add);
+        .add_builtin("add", erase(add));
     let m2 = VmModule::new(m2);
 
     let modules = vec![m1, m2];
@@ -282,7 +282,7 @@ expect_value!(interpreter_builtin_bind,
     args :: None,
     expect :: Value::Int(8),
     builtins :: |vm: VmModule| {
-        vm.add_builtin("add", add)
+        vm.add_builtin("add", erase(add))
     }
 );
 


### PR DESCRIPTION
Require builtin functions to return Futures

- AVM only accepts function of type `Vec<Value> -> Pin<Box<dyn Future<Output=Result<Value, Error>>>>`
- Add `Executor::{execute(), execute_sync()}`
  - `Executor::execute()` executes an instruction and yields or awaits a builtin function
  - `Executor::execute_sync()` blocks until a function finishes execution
    - Uses `futures::executor::block_on()`
- Export function `erase()` which type coerces functions of type `Vec<Value> -> impl Future<Output=Result<Value, Error>>` to `Vec<Value> -> Pin<Box<dyn Future<Output=Result<Value, Error>>>>`
- Update the standard library/tests/examples
