### PR TITLE
SMPL Lazy Width Constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+env:
+  - RUST_MIN_STACK=2500000
 language: rust
 rust:
   - stable

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -919,7 +919,7 @@ impl AbstractWidthConstraint {
 
                 // Gather field constraints from bases
                 for base in struct_bases.into_iter() {
-                    match base {
+                    match base.substitute(universe, scope, typing_context)? {
                         AbstractType::Record {
                             abstract_field_map:
                                 AbstractFieldMapX {

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -790,6 +790,18 @@ impl<X> AbstractFieldMapX<X> {
     }
 }
 
+macro_rules! eval_op {
+    ($self: expr; $p: pat => $e: expr) => { match $self.state {
+        WidthConstraintState::Unevaluated(fields, struct_bases) => {
+            panic!("Cannot perform op on an unevaluated width constraint");
+        }
+
+        WidthConstraintState::Evaluated($p) => {
+            $e
+        }
+    }}
+}
+
 #[derive(Debug, Clone)]
 enum WidthConstraintState<X> {
     Unevaluated(HashMap<Ident, Vec<AbstractTypeX<X>>>, Vec<AbstractTypeX<X>>),
@@ -811,6 +823,18 @@ impl<X> AbstractWidthConstraintX<X> {
 
             WidthConstraintState::Evaluated(..) => Ok(self),
         }
+    }
+
+    pub fn len(&self) -> usize {
+        eval_op!(self; ref fields => fields.len())
+    }
+
+    pub fn fields(&self) -> &HashMap<Ident, AbstractTypeX<X>> {
+        eval_op!(self; ref fields => fields)
+    }
+
+    pub fn fields_iter(&self) -> impl Iterator<Item=(&Ident, &AbstractTypeX<X>)> {
+        eval_op!(self; ref fields => fields.iter())
     }
 
     pub fn downcast(self) -> AbstractWidthConstraintX<()> {

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -852,7 +852,6 @@ impl<X> AbstractWidthConstraintX<X> {
 }
 
 pub fn type_from_ann(
-    universe: &Universe,
     scope: &ScopedData,
     typing_context: &TypingContext,
     anno: &AstNode<TypeAnnotation>,
@@ -899,14 +898,14 @@ pub fn type_from_ann(
                     .map(|node| node.data().clone())
                     .collect(),
             );
-            let type_cons = scope.type_cons(universe, &type_cons_path).ok_or(
+            let type_cons = scope.type_cons(&type_cons_path).ok_or(
                 AnalysisError::UnknownType(typed_path.module_path().clone(), anno.span()),
             )?;
 
             let type_args = typed_path.annotations().map(|ref vec| {
                 vec.iter()
                     .map(|anno| {
-                        type_from_ann(universe, scope, typing_context, &*anno)
+                        type_from_ann(scope, typing_context, &*anno)
                     })
                     .collect::<Result<Vec<_>, _>>()
             });
@@ -926,7 +925,6 @@ pub fn type_from_ann(
 
         TypeAnnotation::Array(ref element_type, size) => {
             let element_type_app = type_from_ann(
-                universe,
                 scope,
                 typing_context,
                 element_type,
@@ -957,7 +955,6 @@ pub fn type_from_ann(
                         .iter()
                         .map(|p| {
                             type_from_ann(
-                                universe,
                                 scope,
                                 typing_context,
                                 p,
@@ -971,7 +968,6 @@ pub fn type_from_ann(
                 .as_ref()
                 .map(|return_type| {
                     type_from_ann(
-                        universe,
                         scope,
                         typing_context,
                         return_type,
@@ -988,7 +984,6 @@ pub fn type_from_ann(
 
         TypeAnnotation::WidthConstraint(ref ast_constraints) => {
             fuse_width_constraints(
-                universe,
                 scope,
                 typing_context,
                 ast_constraints,
@@ -998,7 +993,6 @@ pub fn type_from_ann(
 }
 
 fn fuse_width_constraints(
-    universe: &Universe,
     scope: &ScopedData,
     typing_context: &TypingContext,
     ast_constraints: &[AstNode<WidthConstraint>],
@@ -1023,7 +1017,7 @@ fn fuse_width_constraints(
             //   Laziness required in order to remove Universe parameter on type_from_ann()
             WidthConstraint::BaseStruct(ref ann) => {
                 let ann_type =
-                    type_from_ann(universe, scope, typing_context, ann)?;
+                    type_from_ann(scope, typing_context, ann)?;
 
                 base_structs.push(ann_type);
             }
@@ -1033,7 +1027,6 @@ fn fuse_width_constraints(
             WidthConstraint::Anonymous(ref ident_ann_pairs) => {
                 for (ast_ident, ast_ann) in ident_ann_pairs.iter() {
                     let ann_type = type_from_ann(
-                        universe,
                         scope,
                         typing_context,
                         ast_ann,

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -792,7 +792,7 @@ impl<X> AbstractFieldMapX<X> {
 
 #[derive(Debug, Clone)]
 enum WidthConstraintState<X> {
-    Unevaluated(HashMap<Ident, AbstractTypeX<X>>, Vec<AbstractTypeX<X>>),
+    Unevaluated(HashMap<Ident, Vec<AbstractTypeX<X>>>, Vec<AbstractTypeX<X>>),
     Evaluated(HashMap<Ident, AbstractTypeX<X>>),
 }
 

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -808,6 +808,12 @@ enum WidthConstraintState<X> {
     Evaluated(HashMap<Ident, AbstractTypeX<X>>),
 }
 
+///
+/// To be marked as 'evaluated', the top level types for each field must be resolved
+///    to a single AbstractType. 
+///
+/// Unevaluated width constraints may hold conflicting/invalid constraints.
+///
 #[derive(Debug, Clone)]
 pub struct AbstractWidthConstraintX<X> {
     state: WidthConstraintState<X>

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -814,11 +814,39 @@ impl<X> AbstractWidthConstraintX<X> {
     }
 
     pub fn downcast(self) -> AbstractWidthConstraintX<()> {
+
+        let new_state = match self.state {
+            WidthConstraintState::Unevaluated(fields, base_structs) => {
+                WidthConstraintState::Unevaluated(
+                    fields
+                        .into_iter()
+                        .map(|(i, vec)| {
+                            let vec = vec.into_iter()
+                                .map(|t| t.downcast())
+                                .collect();
+                            (i, vec)
+                        })
+                        .collect(),
+                    base_structs
+                        .into_iter()
+                        .map(|t| t.downcast())
+                        .collect()
+                    )
+                        
+            }
+
+            WidthConstraintState::Evaluated(fields) => {
+                WidthConstraintState::Evaluated(
+                    fields
+                        .into_iter()
+                        .map(|(i, t)| (i, t.downcast()))
+                        .collect()
+                )
+            }
+        };
+
         AbstractWidthConstraintX {
-            fields: self.fields
-                .into_iter()
-                .map(|(ident, at)| (ident, at.downcast()))
-                .collect(),
+            state: new_state
         }
     }
 }

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -814,7 +814,7 @@ impl<X> AbstractFieldMapX<X> {
 
 macro_rules! eval_op {
     ($self: expr; $p: pat => $e: expr) => { match $self.state {
-        WidthConstraintState::Unevaluated(fields, struct_bases) => {
+        WidthConstraintState::Unevaluated(..) => {
             panic!("Cannot perform op on an unevaluated width constraint");
         }
 

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -803,13 +803,13 @@ pub struct AbstractWidthConstraintX<X> {
 
 impl<X> AbstractWidthConstraintX<X> {
 
-    pub(super) fn evaluate(&mut self, universe: &Universe) -> Result<(), AnalysisError> {
-        match self {
+    pub(super) fn evaluate(self, universe: &Universe) -> Result<Self, AnalysisError> {
+        match self.state {
             WidthConstraintState::Unevaluated(fields, struct_bases) => {
                 unimplemented!();
             }
 
-            WidthConstraintState::Evaluated(..) => Ok(()),
+            WidthConstraintState::Evaluated(..) => Ok(self),
         }
     }
 

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -412,7 +412,7 @@ impl AbstractTypeX<Span> {
                 type_cons: ref type_cons_id,
                 args: ref type_args,
             } => {
-                let (ok_args, err) = type_args
+                let (ok_args, mut err) = type_args
                     .iter()
                     .map(|at| {
                         at.substitute_internal(
@@ -554,7 +554,7 @@ impl AbstractTypeX<Span> {
                 ref type_id,
                 ref abstract_field_map,
             } => {
-                let (ok_fields, err) = abstract_field_map
+                let (ok_fields, mut err) = abstract_field_map
                     .fields
                     .iter()
                     .map(|(f_id, ty)| {
@@ -619,7 +619,7 @@ impl AbstractTypeX<Span> {
                 ref parameters,
                 ref return_type,
             } => {
-                let (ok_parameters, errors) = parameters
+                let (ok_parameters, mut errors) = parameters
                     .iter()
                     .map(|p| {
                         p.substitute_internal(
@@ -686,7 +686,7 @@ impl AbstractTypeX<Span> {
                 let width_constraint = width_constraint
                     .clone()
                     .evaluate(universe)?;
-                let (ok_field_types, errors) = width_constraint
+                let (ok_field_types, mut errors) = width_constraint
                     .fields()
                     .iter()
                     .map(|(ident, at)| {
@@ -744,7 +744,7 @@ impl AbstractTypeX<Span> {
                 type_id, 
                 ref args 
             } => {
-                let (ok_args, errors) = args
+                let (ok_args, mut errors) = args
                     .iter()
                     .map(|a| {
                         a.substitute_internal(

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -815,6 +815,20 @@ pub struct AbstractWidthConstraintX<X> {
 
 impl<X> AbstractWidthConstraintX<X> {
 
+    pub fn new_evaluated(map: HashMap<Ident, AbstractTypeX<X>>) -> Self {
+        AbstractWidthConstraintX {
+            state: WidthConstraintState::Evaluated(map),
+        }
+    }
+
+    pub fn is_evaluated(&self) -> bool {
+        if let &WidthConstraintState::Evaluated(..) = &self.state {
+            true
+        } else {
+            false
+        }
+    }
+
     pub(super) fn evaluate(self, universe: &Universe) -> Result<Self, AnalysisError> {
         match self.state {
             WidthConstraintState::Unevaluated(fields, struct_bases) => {

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -668,8 +668,11 @@ impl AbstractTypeX<Span> {
                 data: ref span,
                 width: ref width_constraint
             } => {
+                let width_constraint = width_constraint
+                    .clone()
+                    .evaluate(universe)?;
                 let (ok_field_types, errors) = width_constraint
-                    .fields
+                    .fields()
                     .iter()
                     .map(|(ident, at)| {
                         at.substitute_internal(
@@ -698,9 +701,7 @@ impl AbstractTypeX<Span> {
                     return Err(errors);
                 }
 
-                let new_width = AbstractWidthConstraint {
-                    fields: ok_field_types,
-                };
+                let new_width = AbstractWidthConstraint::new_evaluated(ok_field_types);
 
                 Ok(AbstractType::WidthConstraint {
                     data: span.clone(),

--- a/smpl/src/analysis/abstract_type.rs
+++ b/smpl/src/analysis/abstract_type.rs
@@ -791,11 +791,28 @@ impl<X> AbstractFieldMapX<X> {
 }
 
 #[derive(Debug, Clone)]
+enum WidthConstraintState<X> {
+    Unevaluated(HashMap<Ident, AbstractTypeX<X>>, Vec<AbstractTypeX<X>>),
+    Evaluated(HashMap<Ident, AbstractTypeX<X>>),
+}
+
+#[derive(Debug, Clone)]
 pub struct AbstractWidthConstraintX<X> {
-    pub fields: HashMap<Ident, AbstractTypeX<X>>,
+    state: WidthConstraintState<X>
 }
 
 impl<X> AbstractWidthConstraintX<X> {
+
+    pub(super) fn evaluate(&mut self, universe: &Universe) -> Result<(), AnalysisError> {
+        match self {
+            WidthConstraintState::Unevaluated(fields, struct_bases) => {
+                unimplemented!();
+            }
+
+            WidthConstraintState::Evaluated(..) => Ok(()),
+        }
+    }
+
     pub fn downcast(self) -> AbstractWidthConstraintX<()> {
         AbstractWidthConstraintX {
             fields: self.fields

--- a/smpl/src/analysis/resolve_scope.rs
+++ b/smpl/src/analysis/resolve_scope.rs
@@ -362,7 +362,6 @@ impl ScopedData {
 
     pub fn type_cons<'a, 'b, 'c>(
         &'a self,
-        _universe: &'b Universe,
         path: &'c ModulePath,
     ) -> Option<TypeId> {
         self.type_cons_map.get(path).map(|id| id.clone())

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -250,7 +250,6 @@ macro_rules! ann_to_type {
     ($self: expr, $ann: expr) => {{
         use super::abstract_type;
         abstract_type::type_from_ann(
-            $self.universe,
             $self.scopes.last().expect("Should always have a scope"),
             &$self.typing_context,
             $ann,
@@ -744,14 +743,14 @@ fn resolve_struct_init(
     let type_name = init.type_name();
     let tmp_type_name = type_name.clone().into();
     let struct_type_id = scope
-        .type_cons(universe, &tmp_type_name)
+        .type_cons(&tmp_type_name)
         .ok_or(AnalysisError::UnknownType(type_name.clone(), init_span.clone()))?;
 
     let type_args = init
         .type_args()
         .map(|vec| {
             vec.iter()
-                .map(|ann| type_from_ann(universe, scope, context, ann))
+                .map(|ann| type_from_ann(scope, context, ann))
                 .collect::<Result<Vec<_>, _>>()
         })
         .unwrap_or(Ok(Vec::new()))?;
@@ -1251,7 +1250,7 @@ fn resolve_type_inst(
     let type_args = type_inst
         .args()
         .iter()
-        .map(|ann| type_from_ann(universe, scope, context, ann))
+        .map(|ann| type_from_ann(scope, context, ann))
         .collect::<Result<Vec<_>, _>>()?;
 
     let inst_type = AbstractType::App {

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -872,21 +872,18 @@ fn resolve_anon_struct_init(
     init: &AnonStructInit,
     span: Span,
 ) -> Result<AbstractType, AnalysisError> {
-    let mut width_constraint = AbstractWidthConstraint {
-        fields: HashMap::new(),
-    };
-
+    
+    let mut fields: HashMap<_, AbstractType> = HashMap::new();
     // Map init'd field to its type
     let mut duplicate_fields = Vec::new();
     for (field_name, typed_tmp) in init.raw_field_init() {
         let tmp_type =
             context.tmp_type_map.get(typed_tmp).expect("Missing tmp");
 
-        if width_constraint.fields.contains_key(field_name) {
+        if fields.contains_key(field_name) {
             duplicate_fields.push(field_name.clone());
         } else {
-            width_constraint
-                .fields
+            fields
                 .insert(field_name.clone(), tmp_type.clone());
         }
     }
@@ -901,7 +898,7 @@ fn resolve_anon_struct_init(
 
     let width_type = AbstractType::WidthConstraint {
         data: span,
-        width: width_constraint
+        width: AbstractWidthConstraint::new_evaluated(fields),
     };
     Ok(width_type)
 }

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -1388,19 +1388,22 @@ fn resolve_field_access(
             AbstractType::WidthConstraint {
                 data: width_span,
                 width: awc,
-            } => Ok(Box::new(move |name| {
-                awc.fields().get(name).map(|t| t.clone()).ok_or(
-                    TypeError::UnknownField {
-                        name: name.clone(),
-                        struct_type: AbstractType::WidthConstraint {
-                            data: width_span.clone(),
-                            width: awc.clone(),
-                        },
-                        span: span.clone(),
-                    }
-                    .into(),
-                )
-            })),
+            } => {
+                let awc = awc.evaluate(universe, scope, context)?;
+                Ok(Box::new(move |name| {
+                    awc.fields().get(name).map(|t| t.clone()).ok_or(
+                        TypeError::UnknownField {
+                            name: name.clone(),
+                            struct_type: AbstractType::WidthConstraint {
+                                data: width_span.clone(),
+                                width: awc.clone(),
+                            },
+                            span: span.clone(),
+                        }
+                        .into(),
+                    )
+                }))
+            }
 
             AbstractType::Record {
                 data: record_span,

--- a/smpl/src/analysis/type_checker.rs
+++ b/smpl/src/analysis/type_checker.rs
@@ -1389,7 +1389,7 @@ fn resolve_field_access(
                 data: width_span,
                 width: awc,
             } => Ok(Box::new(move |name| {
-                awc.fields.get(name).map(|t| t.clone()).ok_or(
+                awc.fields().get(name).map(|t| t.clone()).ok_or(
                     TypeError::UnknownField {
                         name: name.clone(),
                         struct_type: AbstractType::WidthConstraint {

--- a/smpl/src/analysis/type_cons_gen.rs
+++ b/smpl/src/analysis/type_cons_gen.rs
@@ -50,7 +50,6 @@ pub fn generate_struct_type_cons(
 
             // TODO: Insert type parameters into scope
             let field_type_app = type_from_ann(
-                universe,
                 &type_param_scope,
                 &type_param_typing_context,
                 field_type_annotation,
@@ -104,7 +103,6 @@ pub fn generate_fn_type_cons(
         Some(ref ann) => {
 
             type_from_ann(
-                universe,
                 &type_param_scope,
                 &type_param_typing_context,
                 ann,
@@ -124,7 +122,6 @@ pub fn generate_fn_type_cons(
                 let param_ann = &param.param_type;
 
                 let param_type = type_from_ann(
-                    universe,
                     &type_param_scope,
                     &type_param_typing_context,
                     param_ann,
@@ -178,7 +175,6 @@ pub fn generate_builtin_fn_type(
     let ret_type = match fn_def.return_type {
         Some(ref anno) => {
             let type_app = type_from_ann(
-                universe,
                 &type_param_scope,
                 &type_param_typing_context,
                 anno,
@@ -204,7 +200,6 @@ pub fn generate_builtin_fn_type(
                     let param_anno = &param.param_type;
 
                     let param_type = type_from_ann(
-                        universe,
                         &type_param_scope,
                         &type_param_typing_context,
                         param_anno,
@@ -268,7 +263,6 @@ pub fn generate_anonymous_fn_type(
         Some(ref ann) => {
 
             type_from_ann(
-                universe,
                 &type_param_scope,
                 &type_param_typing_context,
                 ann,
@@ -288,7 +282,6 @@ pub fn generate_anonymous_fn_type(
                 let param_ann = &param.param_type;
 
                 let param_type = type_from_ann(
-                    universe,
                     &type_param_scope,
                     &type_param_typing_context,
                     param_ann,
@@ -381,7 +374,6 @@ fn type_param_map(
 
                     let ast_constraint = vec_ast_type_ann.get(0).unwrap();
                     let abstract_type = type_from_ann(
-                        universe,
                         &current_scope,
                         &typing_context,
                         ast_constraint,

--- a/smpl/src/analysis/type_equality.rs
+++ b/smpl/src/analysis/type_equality.rs
@@ -77,7 +77,7 @@ pub fn equal_types_static(
                 width: ref constraint_awc,
             },
         ) => {
-            if constraint_awc.fields.len() != synth_awc.fields.len() {
+            if constraint_awc.fields().len() != synth_awc.fields().len() {
                 return Err(TypeError::UnexpectedType {
                     found: synthesis.clone(),
                     expected: constraint.clone(),
@@ -87,9 +87,9 @@ pub fn equal_types_static(
             }
 
             for (constraint_ident, constraint_type) in
-                constraint_awc.fields.iter()
+                constraint_awc.fields().iter()
             {
-                match synth_awc.fields.get(constraint_ident) {
+                match synth_awc.fields().get(constraint_ident) {
                     Some(synth_type) => {
                         equal_types_static(
                             universe,

--- a/smpl/src/analysis/type_equality.rs
+++ b/smpl/src/analysis/type_equality.rs
@@ -15,7 +15,7 @@ pub fn equal_types_static(
     synthesis: &AbstractType,
     constraint: &AbstractType,
     span: Span,
-) -> Result<(), TypeError> {
+) -> Result<(), AnalysisError> {
     use super::abstract_type::AbstractTypeX::*;
 
     match (synthesis, constraint) {

--- a/smpl/src/analysis/type_equality.rs
+++ b/smpl/src/analysis/type_equality.rs
@@ -77,6 +77,13 @@ pub fn equal_types_static(
                 width: ref constraint_awc,
             },
         ) => {
+
+            let constraint_awc = constraint_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
+            let synth_awc = synth_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
             if constraint_awc.fields().len() != synth_awc.fields().len() {
                 return Err(TypeError::UnexpectedType {
                     found: synthesis.clone(),

--- a/smpl/src/analysis/type_resolver.rs
+++ b/smpl/src/analysis/type_resolver.rs
@@ -14,7 +14,7 @@ pub fn resolve_types(
     synthesis: &AbstractType,
     constraint: &AbstractType,
     span: Span,
-) -> Result<(), TypeError> {
+) -> Result<(), AnalysisError> {
     resolve_types_static(
         universe,
         scoped_data,
@@ -33,7 +33,7 @@ pub fn resolve_types_static(
     synthesis: &AbstractType,
     constraint: &AbstractType,
     span: Span,
-) -> Result<(), TypeError> {
+) -> Result<(), AnalysisError> {
     use super::abstract_type::AbstractTypeX::*;
 
     match (synthesis, constraint) {
@@ -399,7 +399,7 @@ fn resolve_param(
     synth: &AbstractType,
     constraint: &AbstractType,
     span: Span,
-) -> Result<(), TypeError> {
+) -> Result<(), AnalysisError> {
     resolve_param_static(
         universe,
         scoped_data,
@@ -417,7 +417,7 @@ fn resolve_param_static(
     synth: &AbstractType,
     constraint: &AbstractType,
     span: Span,
-) -> Result<(), TypeError> {
+) -> Result<(), AnalysisError> {
     use super::abstract_type::AbstractTypeX::*;
 
     match (synth, constraint) {

--- a/smpl/src/analysis/type_resolver.rs
+++ b/smpl/src/analysis/type_resolver.rs
@@ -98,6 +98,12 @@ pub fn resolve_types_static(
                 width: ref constraint_awc,
             },
         ) => {
+            let constraint_awc = constraint_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
+            let synth_awc = synth_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
             for (constraint_ident, constraint_type) in
                 constraint_awc.fields().iter()
             {
@@ -139,6 +145,10 @@ pub fn resolve_types_static(
                 width: ref constraint_awc
             },
         ) => {
+            let constraint_awc = constraint_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
+
             for (constraint_ident, constraint_type) in
                 constraint_awc.fields().iter()
             {
@@ -461,6 +471,13 @@ fn resolve_param_static(
                 width: ref constraint_awc,
             },
         ) => {
+            let constraint_awc = constraint_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
+            let synth_awc = synth_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
+
             for (synth_ident, synth_type) in synth_awc.fields().iter() {
                 match constraint_awc.fields().get(synth_ident) {
                     Some(constraint_type) => {
@@ -502,6 +519,10 @@ fn resolve_param_static(
                 ..
             },
         ) => {
+
+            let synth_awc = synth_awc
+                .clone()
+                .evaluate(universe, scoped_data, typing_context)?;
             for (synth_ident, synth_type) in synth_awc.fields().iter() {
                 match afm.get(synth_ident) {
                     Some(constraint_type) => resolve_types_static(

--- a/smpl/src/analysis/type_resolver.rs
+++ b/smpl/src/analysis/type_resolver.rs
@@ -99,9 +99,9 @@ pub fn resolve_types_static(
             },
         ) => {
             for (constraint_ident, constraint_type) in
-                constraint_awc.fields.iter()
+                constraint_awc.fields().iter()
             {
-                match synth_awc.fields.get(constraint_ident) {
+                match synth_awc.fields().get(constraint_ident) {
                     Some(synth_type) => {
                         resolve_types_static(
                             universe,
@@ -140,7 +140,7 @@ pub fn resolve_types_static(
             },
         ) => {
             for (constraint_ident, constraint_type) in
-                constraint_awc.fields.iter()
+                constraint_awc.fields().iter()
             {
                 match synth_afm.get(constraint_ident) {
                     Some(synth_type) => {
@@ -461,8 +461,8 @@ fn resolve_param_static(
                 width: ref constraint_awc,
             },
         ) => {
-            for (synth_ident, synth_type) in synth_awc.fields.iter() {
-                match constraint_awc.fields.get(synth_ident) {
+            for (synth_ident, synth_type) in synth_awc.fields().iter() {
+                match constraint_awc.fields().get(synth_ident) {
                     Some(constraint_type) => {
                         resolve_types_static(
                             universe,
@@ -502,7 +502,7 @@ fn resolve_param_static(
                 ..
             },
         ) => {
-            for (synth_ident, synth_type) in synth_awc.fields.iter() {
+            for (synth_ident, synth_type) in synth_awc.fields().iter() {
                 match afm.get(synth_ident) {
                     Some(constraint_type) => resolve_types_static(
                         universe,


### PR DESCRIPTION
Do not "eagerly" search through base types of width constraints. 

Width constraints may be created before the base type is inserted into the Universe (e.g. during converting AST type signatures to abstract types), creating an error. Rather, only instantiate base types when required during static analysis of functions (where ALL base types are guaranteed to be in the Universe).

"Normal" types are already lazy because instead of being evaluated, they are instead converted to type applications with the appropriate arity and referencing the correct type constructor. Thus inductively, width constraints containing these "normal" types are also fine. Width constraints only break down in the presence of base types.

Example code which may fail with "eager" width constraints due to definition order evaluation.

```
// Equivalent to:
//   struct Foo { b: { x: int } }
//  but 'Bar' may not yet be in the Universe
struct Foo { b: base Bar }  
struct Bar { x: int }
```

This slightly increases memory consumption, but in future refactorings, it should be feasible to only evaluate width constraints once (also applies to type application).